### PR TITLE
chown -R www-data:www-data /var/log/wsgi

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-
+chown -R www-data:www-data /var/log/wsgi
 PGPASSWORD=$POSTGRES_PASSWORD /usr/bin/psql laalaa -c 'CREATE EXTENSION IF NOT EXISTS postgis;' -U $POSTGRES_USER -h $POSTGRES_HOST
 PGPASSWORD=$POSTGRES_PASSWORD /usr/bin/psql laalaa -c 'CREATE EXTENSION IF NOT EXISTS postgis_topology;' -U $POSTGRES_USER -h $POSTGRES_HOST
 /usr/local/bin/uwsgi --ini /etc/uwsgi/laalaa.ini


### PR DESCRIPTION
Ensure that app logs in /var/log/wsgi have the right ownership permissions on container startup