### PR TITLE
Reduce strain on postcodeinfo service during upload

### DIFF
--- a/conf/uwsgi.ini
+++ b/conf/uwsgi.ini
@@ -10,4 +10,4 @@ enable-threads=True
 processes=2
 harakiri=30
 post-buffering=1
-smart-attach-daemon=/tmp/celery.pid /usr/local/bin/python /home/app/manage.py celery worker -A laalaa --concurrency=10 --loglevel=INFO --pidfile=/tmp/celery.pid
+smart-attach-daemon=/tmp/celery.pid /usr/local/bin/python /home/app/manage.py celery worker -A laalaa --concurrency=2 --loglevel=INFO --pidfile=/tmp/celery.pid

--- a/laalaa/apps/advisers/geocoder.py
+++ b/laalaa/apps/advisers/geocoder.py
@@ -15,10 +15,11 @@ class PostcodeNotFound(GeocoderError):
 
 def geocode(postcode):
     try:
+        postcode_client = postcodeinfo.Client(timeout = 30)
         if len(postcode) < 5:
-            result = postcodeinfo.Client().lookup_partial_postcode(postcode)
+            result = postcode_client.lookup_partial_postcode(postcode)
         else:
-            result = postcodeinfo.Client().lookup_postcode(postcode)
+            result = postcode_client.lookup_postcode(postcode)
 
         if not result.valid:
             result = pc_fallback.geocode(postcode)


### PR DESCRIPTION
## What does this pull request do?

### Increases read timeouts to postcodeinfo service
It seems that the current default of 5 seconds is too low for most of the "legal provider upload" use cases. This is evidenced by the logs of this application.

### Reduce celery worker concurrency to 2 threads
As these workers each make a request to postcodeinfo service, 10 threads tend to overwhelm the service. Reducing the concurrency count seems to be a good stopgap solution.

## Additional context
Once we switch providers we can probably switch this back. Or at least understand if we can do bulk latitude/longitude lookups without so many requests.

⚠️ Needs testing.