### PR TITLE
Build and push Docker images on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,37 @@
 version: 2
 jobs:
+  build:
+    docker:
+      - image: docker:17.03-git
+    environment:
+      DOCKER_REGISTRY: "registry.service.dsd.io"
+      DOCKER_IMAGE: "laalaa"
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 17.03.0-ce
+          docker_layer_caching: true
+      - run:
+          name: Login to container registry
+          command: |
+            docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD --email "${DOCKER_USERNAME}@digital.justice.gov.uk" $DOCKER_REGISTRY
+      - run:
+          name: Build Docker image
+          command: |
+            docker build --tag $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 .
+            docker tag $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_BRANCH.$(git rev-parse --short=7 $CIRCLE_SHA1)
+            docker tag $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_BRANCH.latest
+      - run:
+          name: Validate Python version
+          command: |
+            docker run --rm --tty --interactive $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 python --version | grep "2.7"
+      - run:
+          name: Push Docker image
+          command: |
+            docker push $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1
+            docker push $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_BRANCH.$(git rev-parse --short=7 $CIRCLE_SHA1)
+            docker push $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_BRANCH.latest
+
   test:
     docker:
       - image: circleci/python:2.7
@@ -35,6 +67,9 @@ jobs:
 
 workflows:
   version: 2
-  test:
+  build_and_test:
     jobs:
       - test
+      - build:
+          requires:
+            - test

--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,7 @@
 .sass-cache/
 .tox
 .webassets-cache
+Dockerfile
 app.log
 bin
 build

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ ENV APP_HOME /home/app
 USER app
 EXPOSE 8000
 
-ENTRYPOINT ["/home/app/docker/run.sh"]
+CMD ["/home/app/docker/run.sh"]


### PR DESCRIPTION
## What does this pull request do?

Replaces building Docker images on-demand on self-hosted Jenkins instances with building Docker images automatically on CircleCI.

Similar solution as in https://github.com/ministryofjustice/fala/pull/7, https://github.com/ministryofjustice/cla_public/pull/730