### PR TITLE
LGA-92: Enforce login when accessing the upload page

### DIFF
--- a/laalaa/apps/advisers/views.py
+++ b/laalaa/apps/advisers/views.py
@@ -6,6 +6,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.shortcuts import redirect, render
 from django.views.decorators.cache import never_cache
@@ -165,6 +166,7 @@ class UploadSpreadsheetForm(forms.Form):
 
 
 @never_cache
+@login_required(login_url='/admin/login')
 def upload_spreadsheet(request):
     last_import = Import.objects.all().order_by('-id').first()
 


### PR DESCRIPTION
## What does this pull request do?

Prevents unauthenticated users from accessing the `/admin/upload` page.

📝 There is probably a much better idiomatic way to restrict access to all urls behind `/admin`, so please let me know 😸

I followed https://docs.djangoproject.com/en/1.11/topics/auth/default/#limiting-access-to-logged-in-users.