### PR TITLE
LGA-185: Document the staging and production release of the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Deployment can be triggered via https://ci.service.dsd.io/job/DEPLOY-laalaa.
     ```
 1. [Deploy `feature_branch.<sha>`](https://ci.service.dsd.io/view/LaaLaa/job/DEPLOY-laalaa/build?delay=0sec).
     * `ENVIRONMENT` is the target environment, select "staging".
-    * DEPLOY_BRANCH is the [deploy repo's](https://github.com/ministryofjustice/laalaa-deploy) default branch name, usually master.
-    * VERSION is the branch that needs to be released plus a specific 7-character prefix of the Git SHA. (`dependabot-pip-django-filter-2.0.0.7243223` for the above example).
+    * `DEPLOY_BRANCH` is the [deploy repo's](https://github.com/ministryofjustice/laalaa-deploy) default branch name, usually master.
+    * `VERSION` is the branch that needs to be released plus a specific 7-character prefix of the Git SHA. (`dependabot-pip-django-filter-2.0.0.7243223` for the above example).
 
 ### Releasing to production
 

--- a/README.md
+++ b/README.md
@@ -68,3 +68,33 @@ Go to admin/ and sign in with the admin password you just set.
 The repository unit tests and Docker images are built by CircleCI at https://circleci.com/gh/ministryofjustice/laa-legal-adviser-api.
 
 Deployment can be triggered via https://ci.service.dsd.io/job/DEPLOY-laalaa.
+
+## Releasing
+
+### Releasing to non-production
+
+> Currently, `staging` is the only non-production environment.
+
+1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/laa-legal-adviser-api) for the feature branch.
+1. Copy the `feature_branch.<sha>` reference from the `build` job's "Push Docker image" step. Eg:
+    ```
+    Pushing tag for rev [1ad776954b2e] on {https://registry.service.dsd.io/v1/repositories/laalaa/tags/dependabot-pip-django-filter-2.0.0.7243223}}
+    ```
+1. [Deploy `feature_branch.<sha>`](https://ci.service.dsd.io/view/LaaLaa/job/DEPLOY-laalaa/build?delay=0sec).
+    * `ENVIRONMENT` is the target environment, select "staging".
+    * `DEPLOY_BRANCH` is the branch that needs to be released (`dependabot-pip-django-filter-2.0.0` in the above example).
+    * `VERSION` is either `latest` for the last successful build on that branch, or a specific 7-character prefix of the Git SHA (`7243223` in the above example).
+
+
+### Releasing to production
+
+1. Please make sure you tested on a non-production environment before merging.
+1. Merge your feature branch pull request to `master`.
+1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/laa-legal-adviser-api/tree/master) for the `master` branch.
+1. Copy the `master.<sha>` reference from the `build` job's "Tag and push Docker images" step. Eg:
+    ```
+    Pushing tag for rev [70079f727578] on {https://registry.service.dsd.io/v1/repositories/laalaa/tags/master.9d39b80}
+    ```
+1. [Deploy `master.<sha>` to **prod**uction](https://ci.service.dsd.io/view/LaaLaa/job/DEPLOY-laalaa/build?delay=0sec).
+
+:tada: :shipit:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Deployment can be triggered via https://ci.service.dsd.io/job/DEPLOY-laalaa.
 1. [Deploy `feature_branch.<sha>`](https://ci.service.dsd.io/view/LaaLaa/job/DEPLOY-laalaa/build?delay=0sec).
     * `ENVIRONMENT` is the target environment, select "staging".
     * DEPLOY_BRANCH is the [deploy repo's](https://github.com/ministryofjustice/laalaa-deploy) default branch name, usually master.
-    * VERSION is the branch that needs to be released plus a specific 7-character prefix of the Git SHA. (dependabot-pip-django-filter-2.0.0.7243223 for the above example).
+    * VERSION is the branch that needs to be released plus a specific 7-character prefix of the Git SHA. (`dependabot-pip-django-filter-2.0.0.7243223` for the above example).
 
 ### Releasing to production
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,8 @@ Deployment can be triggered via https://ci.service.dsd.io/job/DEPLOY-laalaa.
     ```
 1. [Deploy `feature_branch.<sha>`](https://ci.service.dsd.io/view/LaaLaa/job/DEPLOY-laalaa/build?delay=0sec).
     * `ENVIRONMENT` is the target environment, select "staging".
-    * `DEPLOY_BRANCH` is the branch that needs to be released (`dependabot-pip-django-filter-2.0.0` in the above example).
-    * `VERSION` is either `latest` for the last successful build on that branch, or a specific 7-character prefix of the Git SHA (`7243223` in the above example).
-
+    * DEPLOY_BRANCH is the [deploy repo's](https://github.com/ministryofjustice/laalaa-deploy) default branch name, usually master.
+    * VERSION is the branch that needs to be released plus a specific 7-character prefix of the Git SHA. (dependabot-pip-django-filter-2.0.0.7243223 for the above example).
 
 ### Releasing to production
 


### PR DESCRIPTION
## What does this pull request do?

Documents the release process for this application for both non-production and production releases.

🔎 Nicer link to the new section: https://github.com/ministryofjustice/laa-legal-adviser-api/blob/instructions-for-release/README.md

![screen shot 2018-08-30 at 15 32 21](https://user-images.githubusercontent.com/89347/44858473-05494980-ac6a-11e8-8485-46d88a5565a0.png)

## Any other changes that would benefit highlighting?

No