### PR TITLE
Simplify ping.json

### DIFF
--- a/laalaa/apps/advisers/middleware.py
+++ b/laalaa/apps/advisers/middleware.py
@@ -1,0 +1,17 @@
+from django.http import HttpResponse
+
+class PingMiddleware(object):
+  def __init__(self, get_response):
+    self.get_response = get_response
+
+  def __call__(self, request):
+    if request.method == "GET":
+      if request.path == "/ping.json":
+        return self.ping(request)
+    return self.get_response(request)
+
+  def ping(self, request):
+    """
+    Returns that the server is alive.
+    """
+    return HttpResponse("OK")

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -35,7 +35,6 @@ TEMPLATE_DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 
-
 # Application definition
 
 INSTALLED_APPS = (
@@ -53,7 +52,8 @@ INSTALLED_APPS = (
     'advisers',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
+    'advisers.middleware.PingMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/laalaa/urls.py
+++ b/laalaa/urls.py
@@ -4,15 +4,9 @@ from django.conf.urls.static import static
 from django.views.decorators.cache import never_cache
 
 from advisers.admin import admin_site
-from moj_irat.views import PingJsonView, HealthcheckView
+from moj_irat.views import HealthcheckView
 
 urlpatterns = [
-    url(r'^ping.json$', never_cache(PingJsonView.as_view(
-        build_tag_key='APP_BUILD_TAG',
-        build_date_key='APP_BUILD_DATE',
-        commit_id_key='APP_GIT_COMMIT',
-        version_number_key='APPVERSION',
-    )), name='ping_json'),
     url(r'^healthcheck.json$', never_cache(HealthcheckView.as_view()), name='healthcheck_json'),
     url(r'^admin/', include(admin_site.urls)),
     url(r'^', include('advisers.urls'))


### PR DESCRIPTION
## What does this pull request do?

This pull requests simplifies the response of /ping.json. It returns a 200 if the server is alive.

Previous to this, `ping.json` was changed to use `moj-django-irat`. As part of this change, the response remained true to the [ping.json schema](https://github.com/ministryofjustice/ping.json/blob/master/ping.json). However, there was an existing bug where the values were not being set. We didn't attempt to fix this as part of the previous change to `moj-django-irat`. We wrongly assumed /ping.json would still return a status of `200`.

It didn't. It returned a `501` because two values were not set:

```python
if not response_data['build_date'] or not response_data['commit_id']:
   response.status_code = 501
```
[See the code here](https://github.com/ministryofjustice/django-moj-irat/blob/c1588426fffce783bef6d8b9d73395a5e9a833c9/moj_irat/views.py#L38-L39).

## Any other changes that would benefit highlighting?

The liveliness check is implemented as Django middleware, following the suggestion here: https://www.ianlewis.org/en/kubernetes-health-checks-django

The middleware is called `LivelinessMiddleware` as part of the move to liveliness and readiness healthchecks that we'll soon be introducing as part of the move to Kubernetes. 

The endpoint `ping.json` is still in place because the loadbalancers currently rely on this.

The other thing to note is that:

>**Deprecated since version 1.10:**
>Old-style middleware that uses settings.MIDDLEWARE_CLASSES are deprecated. Adapt old, custom middleware and use the MIDDLEWARE setting.

https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-MIDDLEWARE

