### PR TITLE
Inject django config into celery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,13 @@ services:
       - db
       - rabbitmq
 
+  start_app:
+    image: jwilder/dockerize
+    command: >
+      -wait tcp://laalaa:8000 --timeout 60s
+    depends_on:
+      - laalaa
+
   # services
   db:
     image: circleci/postgres:9.4-alpine-postgis
@@ -32,4 +39,21 @@ services:
         published: 15672
         protocol: tcp
         mode: host
-  
+
+  # application
+  laalaa:
+    build: .
+    ports:
+      - target: 8000
+        published: 8000
+        protocol: tcp
+        mode: host
+    environment:
+      DB_USERNAME: postgres
+      DB_PASSWORD: 
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: laalaa
+      HOST_IP: rabbitmq
+      RABBITMQ_USER: guest
+      RABBITMQ_PASS: guest

--- a/laalaa/apps/advisers/healthchecks.py
+++ b/laalaa/apps/advisers/healthchecks.py
@@ -6,10 +6,16 @@ class CeleryWorkersHealthcheck(object):
         self.name = name
     
     def __call__(self, *args, **kwargs):
+        import os
         from celery import Celery
+        os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'laalaa.settings')
+        from django.conf import settings
         
         try:
             app = Celery('laalaa')
+            app.config_from_object('django.conf:settings')
+            app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
             stats = app.control.inspect().stats()
             if not stats:
                 return self.error_response('No running workers were found.')

--- a/laalaa/apps/advisers/healthchecks.py
+++ b/laalaa/apps/advisers/healthchecks.py
@@ -6,28 +6,29 @@ class CeleryWorkersHealthcheck(object):
         self.name = name
     
     def __call__(self, *args, **kwargs):
-        import os
         from celery import Celery
-        os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'laalaa.settings')
         from django.conf import settings
         
         try:
             app = Celery('laalaa')
             app.config_from_object('django.conf:settings')
-            app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
-
             stats = app.control.inspect().stats()
+
             if not stats:
                 return self.error_response('No running workers were found.')
+            
             workers = stats.values()
             if not workers:
                 return self.error_response('No workers running.')
+
         except IOError as e:
             msg = str(e)
             msg += '. Check that the message broker is running.'
             return self.error_response(msg)
+
         except ImportError as e:
             return self.error_response(str(e))
+            
         return self.success_response()
         
     def error_response(self, error):

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -232,9 +232,9 @@ if 'SENTRY_DSN' in os.environ:
         'raven.contrib.django.raven_compat',
     )
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE = (
         'raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware',
-    ) + MIDDLEWARE_CLASSES
+    ) + MIDDLEWARE
 
 
 # .local.py overrides all the common settings.

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -232,9 +232,9 @@ if 'SENTRY_DSN' in os.environ:
         'raven.contrib.django.raven_compat',
     )
 
-    MIDDLEWARE = (
+    MIDDLEWARE_CLASSES = (
         'raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware',
-    ) + MIDDLEWARE
+    ) + MIDDLEWARE_CLASSES
 
 
 # .local.py overrides all the common settings.


### PR DESCRIPTION
## What does this pull request do?

This pull request injects the django app config into the celery app that is started in the healthcheck. Before this change was made, the healthcheck wrongly reported that a connection to celery couldn't be made.

## Any other changes that would benefit highlighting?
I added to the `docker-compose.yml` in order to easily run and test the app inside a docker container.

`MIDDLEWARE` was changed back to `MIDDLEWARE_CLASSES` - see https://github.com/ministryofjustice/laa-legal-adviser-api/pull/65 for reasons.
