### PR TITLE
Switch back to old style of Django middleware

### DIFF
--- a/laalaa/apps/advisers/middleware.py
+++ b/laalaa/apps/advisers/middleware.py
@@ -1,14 +1,11 @@
 from django.http import HttpResponse
 
-class PingMiddleware(object):
-  def __init__(self, get_response):
-    self.get_response = get_response
-
-  def __call__(self, request):
+class PingMiddleware():
+  def process_request(self, request):
     if request.method == "GET":
       if request.path == "/ping.json":
         return self.ping(request)
-    return self.get_response(request)
+    pass
 
   def ping(self, request):
     """

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -52,7 +52,7 @@ INSTALLED_APPS = (
     'advisers',
 )
 
-MIDDLEWARE = (
+MIDDLEWARE_CLASSES = (
     'advisers.middleware.PingMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
## What does this pull request do?

In [a previous pull request](https://github.com/ministryofjustice/laa-legal-adviser-api/pull/63), we introduced `PingMiddleware`, and took the opportunity to switch to the new style of middleware by using the `MIDDLEWARE` setting instead of the `MIDDLEWARE_CLASSES` setting.

`PingMiddleware` was written in the new style. And the [upgrade documentation](https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-middleware) suggested:

>All middleware classes included with Django are compatible with both settings.

Unfortunately, we got this error:

```
Traceback (most recent call last):
  File "./laalaa/wsgi.py", line 14, in <module>
    application = get_wsgi_application()
  File "/usr/local/lib/python2.7/site-packages/django/core/wsgi.py", line 14, in get_wsgi_application
    return WSGIHandler()
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 151, in __init__
    self.load_middleware()
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 82, in load_middleware
    mw_instance = middleware(handler)
TypeError: object() takes no parameters
unable to load app 0 (mountpoint='') (callable not found or import error)
```

on our staging environment when the laalaa container was started.

This is likely because of a middleware class is not compatible with the new style.

Rather than fix this now, this pull requests reverts to the older style of middleware. Therefore, `PingMiddleware` is now written in the pre-1.10 style.

## Any other changes that would benefit highlighting?

Nothing.