### PR TITLE
Revert string normalisation on psql_command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           name: Check formatting with Black
           command: |
             source lint-env/bin/activate
-            black --check laalaa
+            black --check --skip-string-normalization laalaa
   test:
     docker:
       - image: circleci/python:2.7

--- a/laalaa/apps/advisers/tasks.py
+++ b/laalaa/apps/advisers/tasks.py
@@ -229,15 +229,15 @@ class ProgressiveAdviserImport(Task):
         cursor.execute("DELETE FROM {table}".format(table=table_name))
 
         psql_command = [
-            "export PGPASSWORD=%s &&" % settings.DATABASES["default"]["PASSWORD"],
-            "psql",
-            settings.DATABASES["default"]["NAME"],
-            "-U",
-            settings.DATABASES["default"]["USER"],
-            "-h",
-            settings.DATABASES["default"]["HOST"],
-            "-c",
-            r'"\copy {table} FROM {filename} DELIMITER \',\' CSV HEADER;"'.format(
+            'export PGPASSWORD=%s &&' % settings.DATABASES['default']['PASSWORD'],
+            'psql',
+            settings.DATABASES['default']['NAME'],
+            '-U',
+            settings.DATABASES['default']['USER'],
+            '-h',
+            settings.DATABASES['default']['HOST'],
+            '-c',
+            '"\copy {table} FROM {filename} DELIMITER \',\' CSV HEADER;"'.format(
                 table=table_name, filename=csv_filename
             ),
         ]

--- a/laalaa/apps/advisers/tasks.py
+++ b/laalaa/apps/advisers/tasks.py
@@ -239,7 +239,7 @@ class ProgressiveAdviserImport(Task):
             '-c',
             '"\copy {table} FROM {filename} DELIMITER \',\' CSV HEADER;"'.format(
                 table=table_name, filename=csv_filename
-            ),
+            ),  # noqa: W605
         ]
 
         os.system(" ".join(psql_command))


### PR DESCRIPTION
## What does this pull request do?

Hotfix to revert string normalisation on `psql_command`

## Any other changes that would benefit highlighting?

Configure string normalisation skip in lint job