### PR TITLE
LGA-531 - Integrate with new staging environment via Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  build_web:
     docker:
       - image: docker:17.03-git
     environment:
@@ -20,7 +20,7 @@ jobs:
           command: |
             apk add --no-cache --no-progress py2-pip
             pip install awscli
-            ecr_login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
+            ecr_login="$(AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)"
             ${ecr_login}
       - run:
           name: Build Docker image
@@ -38,6 +38,34 @@ jobs:
           command: |
             .circleci/tag_and_push_docker_image application:$CIRCLE_SHA1 $DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE
             .circleci/tag_and_push_docker_image application:$CIRCLE_SHA1 ${ECR_DOCKER_REPO_BASE}
+  build_nginx:
+    docker:
+      - image: docker:18.05.0-git
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 18.05.0-ce
+          docker_layer_caching: true
+      - run:
+          name: Login to the ECR Docker registry
+          command: |
+            apk add --no-cache --no-progress py2-pip
+            pip install awscli
+            ecr_login="$(AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)"
+            ${ecr_login}
+      - run:
+          name: Build Docker image
+          command: |
+            docker build --file Dockerfile.nginx --tag nginx:$CIRCLE_SHA1 \
+              --label build.git.sha=$CIRCLE_SHA1 \
+              --label build.git.branch=$CIRCLE_BRANCH \
+              --label build.url=$CIRCLE_BUILD_URL \
+              .
+      - run:
+          name: Tag and push Docker images
+          command: .circleci/tag_and_push_docker_image \
+              nginx:$CIRCLE_SHA1 \
+              ${ECR_DOCKER_REPO_BASE}-nginx
   lint:
     docker:
       - image: circleci/python:3.7
@@ -102,13 +130,42 @@ jobs:
             source env/bin/activate
             python manage.py test
 
+  staging_deploy:
+    docker:
+      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+    steps:
+      - checkout
+      - run:
+          name: Initialise Kubernetes staging context
+          command: |
+            setup-kube-auth
+            kubectl config use-context staging
+      - deploy:
+          name: Deploy laalaa to staging
+          command: |
+            .circleci/deploy_to_kubernetes staging ${ECR_DOCKER_REPO_BASE}-webapp ${ECR_DOCKER_REPO_BASE}-nginx 
+      - deploy:
+          name: Notify Slack channel
+          command: .circleci/notify_slack_channel staging
+
 workflows:
   version: 2
   build_and_test:
     jobs:
       - lint
       - test
-      - build:
+      - build_web:
           requires:
             - lint
             - test
+      - build_nginx:
+          requires:
+            - test
+      - staging_deploy_approval:
+          type: approval
+          requires:
+            - build_web
+            - build_nginx
+      - staging_deploy:
+          requires:
+            - staging_deploy_approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,34 +38,6 @@ jobs:
           command: |
             .circleci/tag_and_push_docker_image application:$CIRCLE_SHA1 $DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE
             .circleci/tag_and_push_docker_image application:$CIRCLE_SHA1 ${ECR_DOCKER_REPO_BASE}
-  build_nginx:
-    docker:
-      - image: docker:18.05.0-git
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: 18.05.0-ce
-          docker_layer_caching: true
-      - run:
-          name: Login to the ECR Docker registry
-          command: |
-            apk add --no-cache --no-progress py2-pip
-            pip install awscli
-            ecr_login="$(AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)"
-            ${ecr_login}
-      - run:
-          name: Build Docker image
-          command: |
-            docker build --file Dockerfile.nginx --tag nginx:$CIRCLE_SHA1 \
-              --label build.git.sha=$CIRCLE_SHA1 \
-              --label build.git.branch=$CIRCLE_BRANCH \
-              --label build.url=$CIRCLE_BUILD_URL \
-              .
-      - run:
-          name: Tag and push Docker images
-          command: .circleci/tag_and_push_docker_image \
-              nginx:$CIRCLE_SHA1 \
-              ${ECR_DOCKER_REPO_BASE}-nginx
   lint:
     docker:
       - image: circleci/python:3.7
@@ -143,7 +115,7 @@ jobs:
       - deploy:
           name: Deploy laalaa to staging
           command: |
-            .circleci/deploy_to_kubernetes staging ${ECR_DOCKER_REPO_BASE}-webapp ${ECR_DOCKER_REPO_BASE}-nginx 
+            .circleci/deploy_to_kubernetes staging ${ECR_DOCKER_REPO_BASE}
       - deploy:
           name: Notify Slack channel
           command: .circleci/notify_slack_channel staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
       - deploy:
           name: Deploy laalaa to staging
           command: |
-            .circleci/deploy_to_kubernetes staging ${ECR_DOCKER_REPO_BASE}
+            .circleci/deploy_to_kubernetes staging
       - deploy:
           name: Notify Slack channel
           command: .circleci/notify_slack_channel staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build_web:
+  build:
     docker:
       - image: docker:17.03-git
     environment:
@@ -126,14 +126,14 @@ workflows:
     jobs:
       - lint
       - test
-      - build_web:
+      - build:
           requires:
             - lint
             - test
       - staging_deploy_approval:
           type: approval
           requires:
-            - build_web
+            - build
       - staging_deploy:
           requires:
             - staging_deploy_approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: |
             apk add --no-cache --no-progress py2-pip
             pip install awscli
-            ecr_login="$(AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)"
+            ecr_login="$(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)"
             ${ecr_login}
       - run:
           name: Build Docker image
@@ -158,14 +158,10 @@ workflows:
           requires:
             - lint
             - test
-      - build_nginx:
-          requires:
-            - test
       - staging_deploy_approval:
           type: approval
           requires:
             - build_web
-            - build_nginx
       - staging_deploy:
           requires:
             - staging_deploy_approval

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,5 +1,4 @@
 #!/bin/sh -e
 safe_git_branch=${CIRCLE_BRANCH//\//-}
 short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
-export deploy_image_and_tag="$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
-export ECR_DEPLOY_IMAGE="$ECR_DOCKER_REGISTRY/$deploy_image_and_tag"
+ECR_DEPLOY_IMAGE="$ECR_DOCKER_REPO_BASE:$safe_git_branch.$short_sha"

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,3 +1,5 @@
 #!/bin/sh -e
 safe_git_branch=${CIRCLE_BRANCH//\//-}
 short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
+export deploy_image_and_tag="$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
+export ECR_DEPLOY_IMAGE="$ECR_DOCKER_REGISTRY/$deploy_image_and_tag"

--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -1,0 +1,36 @@
+#!/bin/sh -eu
+
+ROOT=$(dirname "$0")
+NAMESPACE="$1"
+NAMESPACE_DIR="$ROOT/../kubernetes_deploy/$NAMESPACE"
+WEBAPP_REPO="$2"
+NGINX_REPO="$3"
+
+if ! [ $NAMESPACE ] ; then
+
+  echo "usage: deploy_to_kubernetes namespace\n"
+  echo "namespace is a directory in ../kubernetes_deploy/ directory"
+  exit 1;
+fi
+
+if ! [ -d $NAMESPACE_DIR ] ; then
+  echo "$NAMESPACE_DIR not found"
+  exit 1;
+fi
+
+source "$ROOT/define_build_environment_variables"
+ECR_WEBAPP_DEPLOY_IMAGE="$WEBAPP_REPO:$safe_git_branch.$short_sha"
+ECR_NGINX_DEPLOY_IMAGE="$NGINX_REPO:$safe_git_branch.$short_sha"
+
+echo "Deploying $ECR_WEBAPP_DEPLOY_IMAGE to $NAMESPACE..."
+echo "Deploying $ECR_NGINX_DEPLOY_IMAGE to $NAMESPACE..."
+
+kubectl set image --filename="$NAMESPACE_DIR/deployment.yml" --local --output=yaml \
+  webapp="$ECR_WEBAPP_DEPLOY_IMAGE" nginx="$ECR_NGINX_DEPLOY_IMAGE" | \
+  kubectl apply \
+    --filename=/dev/stdin \
+    --filename="$NAMESPACE_DIR/service.yml" \
+    --filename="$NAMESPACE_DIR/ingress.yml" \
+    --filename="$NAMESPACE_DIR/dashboard.yml" \
+    --filename="$NAMESPACE_DIR/certificate.yml"
+

--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -1,36 +1,33 @@
-#!/bin/sh -eu
+#!/bin/bash -e
+set -o pipefail
 
 ROOT=$(dirname "$0")
 NAMESPACE="$1"
 NAMESPACE_DIR="$ROOT/../kubernetes_deploy/$NAMESPACE"
-WEBAPP_REPO="$2"
-NGINX_REPO="$3"
 
-if ! [ $NAMESPACE ] ; then
-
-  echo "usage: deploy_to_kubernetes namespace\n"
+if [ -z "$NAMESPACE" ] ; then
+  printf "usage: deploy_to_kubernetes namespace\n"
   echo "namespace is a directory in ../kubernetes_deploy/ directory"
-  exit 1;
+  exit 1
 fi
 
-if ! [ -d $NAMESPACE_DIR ] ; then
+if ! [ -d "$NAMESPACE_DIR" ] ; then
   echo "$NAMESPACE_DIR not found"
-  exit 1;
+  exit 1
 fi
 
-source "$ROOT/define_build_environment_variables"
-ECR_WEBAPP_DEPLOY_IMAGE="$WEBAPP_REPO:$safe_git_branch.$short_sha"
-ECR_NGINX_DEPLOY_IMAGE="$NGINX_REPO:$safe_git_branch.$short_sha"
+if [ -z "$ECR_DEPLOY_IMAGE" ] ; then
+  source "$ROOT"/define_build_environment_variables
+fi
 
-echo "Deploying $ECR_WEBAPP_DEPLOY_IMAGE to $NAMESPACE..."
-echo "Deploying $ECR_NGINX_DEPLOY_IMAGE to $NAMESPACE..."
+echo "Deploying $ECR_DEPLOY_IMAGE to $NAMESPACE..."
 
-kubectl set image --filename="$NAMESPACE_DIR/deployment.yml" --local --output=yaml \
-  webapp="$ECR_WEBAPP_DEPLOY_IMAGE" nginx="$ECR_NGINX_DEPLOY_IMAGE" | \
-  kubectl apply \
-    --filename=/dev/stdin \
-    --filename="$NAMESPACE_DIR/service.yml" \
-    --filename="$NAMESPACE_DIR/ingress.yml" \
-    --filename="$NAMESPACE_DIR/dashboard.yml" \
-    --filename="$NAMESPACE_DIR/certificate.yml"
-
+# shellcheck disable=SC2002 # Useless cat, https://www.shellcheck.net/wiki/SC2002
+# Using a separate cat command here helps in separating the pipe of
+# "altering" kubectl commands which all take something from stdin and write to stdout.
+cat "$NAMESPACE_DIR/deployment.yml" | \
+  kubectl set image app="$ECR_DEPLOY_IMAGE" --filename=/dev/stdin --local --output=yaml | \
+  kubectl annotate kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --filename=/dev/stdin --local --output=yaml | \
+  kubectl apply --record=false \
+    --filename="$NAMESPACE_DIR/" \
+    --filename=/dev/stdin

--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -33,5 +33,6 @@ cat "$NAMESPACE_DIR/deployment.yml" | \
   kubectl set image app="$ECR_DEPLOY_IMAGE" --filename=/dev/stdin --local --output=yaml | \
   kubectl annotate kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --filename=/dev/stdin --local --output=yaml | \
   kubectl apply --record=false \
-    --filename="$NAMESPACE_DIR/" \
-    --filename=/dev/stdin
+    --filename=/dev/stdin \
+    --filename="$NAMESPACE_DIR/service.yml" \
+    --filename="$NAMESPACE_DIR/ingress.yml"

--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -25,10 +25,6 @@ echo "Deploying $ECR_DEPLOY_IMAGE to $NAMESPACE..."
 # shellcheck disable=SC2002 # Useless cat, https://www.shellcheck.net/wiki/SC2002
 # Using a separate cat command here helps in separating the pipe of
 # "altering" kubectl commands which all take something from stdin and write to stdout.
-echo "NAMESPACE_DIR $NAMESPACE_DIR"
-echo "ECR_DEPLOY_IMAGE $ECR_DEPLOY_IMAGE"
-echo "CIRCLE_BUILD_URL $CIRCLE_BUILD_URL"
-
 cat "$NAMESPACE_DIR/deployment.yml" | \
   kubectl set image app="$ECR_DEPLOY_IMAGE" --filename=/dev/stdin --local --output=yaml | \
   kubectl annotate kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --filename=/dev/stdin --local --output=yaml | \

--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -25,6 +25,10 @@ echo "Deploying $ECR_DEPLOY_IMAGE to $NAMESPACE..."
 # shellcheck disable=SC2002 # Useless cat, https://www.shellcheck.net/wiki/SC2002
 # Using a separate cat command here helps in separating the pipe of
 # "altering" kubectl commands which all take something from stdin and write to stdout.
+echo "NAMESPACE_DIR $NAMESPACE_DIR"
+echo "ECR_DEPLOY_IMAGE $ECR_DEPLOY_IMAGE"
+echo "CIRCLE_BUILD_URL $CIRCLE_BUILD_URL"
+
 cat "$NAMESPACE_DIR/deployment.yml" | \
   kubectl set image app="$ECR_DEPLOY_IMAGE" --filename=/dev/stdin --local --output=yaml | \
   kubectl annotate kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --filename=/dev/stdin --local --output=yaml | \

--- a/.circleci/notify_slack_channel
+++ b/.circleci/notify_slack_channel
@@ -1,0 +1,21 @@
+#!/bin/sh -e
+
+source $(dirname "$0")/define_build_environment_variables
+environment="$1"
+
+github_repo_url="${CIRCLE_REPOSITORY_URL//git@github.com:/https://github.com/}"
+github_repo_url="${github_repo_url//.git/}"
+
+cat <<END > payload.json
+{
+  "text": ":tada: Deployed \`${github_repo_url}/commit/$short_sha\` to *$environment*.",
+  "attachments": [
+    {
+      "fallback": "<$CIRCLE_BUILD_URL|View build>",
+      "actions": [{"type": "button", "text": "View build", "url": "$CIRCLE_BUILD_URL"}]
+    }
+  ]
+}
+END
+
+curl --request POST --data @payload.json --header "Content-Type: application/json" $SLACK_WEBHOOK_URL

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -9,7 +9,7 @@ function tag_and_push() {
   echo
   echo "Tagging and pushing $tag..."
   docker tag $built_tag $tag
-  docker push $tag
+  docker push $tag || docker push $tag || docker push $tag
 }
 
 if [ "$CIRCLE_BRANCH" == "master" ]; then

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -9,7 +9,7 @@ function tag_and_push() {
   echo
   echo "Tagging and pushing $tag..."
   docker tag $built_tag $tag
-  docker push $tag || docker push $tag || docker push $tag
+  docker push $tag
 }
 
 if [ "$CIRCLE_BRANCH" == "master" ]; then

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -1,0 +1,44 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
+  name: laa-legal-adviser-api
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: laa-legal-adviser-api
+        env: staging
+        service_area: laa-get-access
+        service_team: cla-fala
+    spec:
+      containers:
+      - image: "<to be set by deploy_to_kubernetes>"
+        name: app
+        readinessProbe:
+          httpGet:
+            path: /ping.json
+            port: 80
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /ping.json
+            port: 80
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+          periodSeconds: 10
+        ports:
+        - containerPort: 80
+          name: http
+        env:
+        - name: LOG_LEVEL
+          value: INFO
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret-key
+              key: SECRET_KEY

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -17,23 +17,6 @@ spec:
       containers:
       - image: "<to be set by deploy_to_kubernetes>"
         name: app
-        readinessProbe:
-          httpGet:
-            path: /ping.json
-            port: 80
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
-          periodSeconds: 10
-        livenessProbe:
-          httpGet:
-            path: /ping.json
-            port: 80
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
-          periodSeconds: 10
-        ports:
-        - containerPort: 80
-          name: http
         env:
         - name: LOG_LEVEL
           value: INFO

--- a/kubernetes_deploy/staging/ingress.yml
+++ b/kubernetes_deploy/staging/ingress.yml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: laa-legal-adviser-api
+  namespace: laa-legal-adviser-api-staging
+spec:
+  tls:
+  - hosts:
+    - laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: laa-legal-adviser-api
+          servicePort: 80

--- a/kubernetes_deploy/staging/service.yml
+++ b/kubernetes_deploy/staging/service.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: laa-legal-adviser-api
+  namespace: laa-legal-adviser-api-staging
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: 80
+  selector:
+    app: laa-legal-adviser-api-app


### PR DESCRIPTION
## What does this pull request do?
 - Modifies the circleci build process to take the ECR region from env vars rather than hard-coded to eu-west-1
 - Adds steps to the circleci workflow to deploy to staging using Kubernetes, after a confirmation step (the pods currently fail with a `CreateContainerConfigError` but I think that's reaching into the scope of future tickets rather than the environment and integration)

## Any other changes that would benefit highlighting?

Uses a number of environment variables that have been added on circleci:

- `AWS_ACCESS_KEY_ID` From `ecr-repo-laa-legal-adviser-api` Kubernetes secret
- `AWS_DEFAULT_REGION` `eu-west-2` here
- `AWS_SECRET_ACCESS_KEY` From `ecr-repo-laa-legal-adviser-api` Kubernetes secret
- `ECR_DOCKER_REPO_BASE` From `ecr-repo-laa-legal-adviser-api` Kubernetes secret
- `ECR_ENDPOINT` Same as the value of `ECR_DOCKER_REPO_BASE` up to and including `amazonaws.com` ie without the image identifier
- `KUBE_ENV_STAGING_CACERT` From `circleci-token-xxxxx` Kubernetes secret
- `KUBE_ENV_STAGING_NAME` Cluster name ie `live-1.cloud-platform.service.justice.gov.uk` here
- `KUBE_ENV_STAGING_NAMESPACE` Namespace name ie `laa-legal-adviser-api-staging` here
- `KUBE_ENV_STAGING_TOKEN` From `circleci-token-xxxxx` Kubernetes secret
- `SLACK_WEBHOOK_URL` Same value as our other apps

Doesn't affect the DSD image build and push for template deploys

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
