### PR TITLE
LGA-534: Add env vars to set during deployment, from secrets

### DIFF
--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -25,3 +25,28 @@ spec:
             secretKeyRef:
               name: secret-key
               key: SECRET_KEY
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: sentry
+              key: dsn
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: db
+              key: username
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: db
+              key: password
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: db
+              key: host
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: db
+              key: port


### PR DESCRIPTION
## What does this pull request do?

Sets Sentry DSN and database credentials in Kubernetes deploy

## Any other changes that would benefit highlighting?

Not all are secret, but they're all specific to a given deployment (ie
not just a staging environment, but a particular staging environment)

Config not copied from template deploy:

- ADDRESSFINDER_API_TOKEN - No longer use addressfinder
- ADDRESSFINDER_API_HOST - No longer use addressfinder
- POSTCODEINFO_API_TOKEN - No longer use postcodeinfo
- POSTCODEINFO_AUTH_TOKEN - No longer use postcodeinfo
- RABBITMQ_USER - We're going to be changing our MQ setup
- RABBITMQ_PASS - We're going to be changing our MQ setup
- HOST_IP - Don't know what this needs set to, if anything

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
