### PR TITLE
LGA-643 - Non root container user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN  chown -R app: /home/app
 ENV HOME /home/app
 WORKDIR /home/app
 ENV APP_HOME /home/app
-USER app
+USER 1000
 EXPOSE 8000
 
 CMD ["/home/app/docker/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM phusion/baseimage:0.9.16
 MAINTAINER Stuart Munro <stuart.munro@digital.justice.gov.uk>
 
 # Runtime User
-RUN useradd -m -d /home/app app
+RUN useradd --uid 1000 --user-group -m -d /home/app app
 
 # Set timezone
 RUN echo "Europe/London" > /etc/timezone  &&  dpkg-reconfigure -f noninteractive tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN  chown -R app: /home/app
 ENV HOME /home/app
 WORKDIR /home/app
 ENV APP_HOME /home/app
+# Specify the user by numeric ID, for environments which use the ID to determine that the user is non-root
 USER 1000
 EXPOSE 8000
 

--- a/docker/setup_postgres.sh
+++ b/docker/setup_postgres.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DB_NAME=${1:-$DB_USERNAME}  # Until we move off template deploy and onto Kubernetes with the new DB
+DB_NAME=${DB_NAME:-$DB_USERNAME}  # Until we move off template deploy and onto Kubernetes with the new DB
 
 PGPASSWORD=$DB_PASSWORD /usr/bin/psql --host $DB_HOST -U $DB_USERNAME $DB_NAME -c 'CREATE EXTENSION IF NOT EXISTS postgis;'
 PGPASSWORD=$DB_PASSWORD /usr/bin/psql --host $DB_HOST -U $DB_USERNAME $DB_NAME -c 'CREATE EXTENSION IF NOT EXISTS postgis_topology;'


### PR DESCRIPTION
## What does this pull request do?

Specifies a non-root ID for the user that we run the app as

## Any other changes that would benefit highlighting?

Also fixes the fallback when DB_NAME isn't set (eg by our cloud formation template deploy), which had an error in it.

The user ID must be specified numerically, due to the constraint in the platform: https://user-guide.cloud-platform.service.justice.gov.uk/tasks.html#how-to-adapt-to-the-pod-security-policies

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
