### PR TITLE
LGA-648 - Add configuration for deploying to local kubernetes

### DIFF
--- a/kubernetes_deploy/development/deployment.yml
+++ b/kubernetes_deploy/development/deployment.yml
@@ -41,5 +41,5 @@ spec:
           value: postgres
         - name: POSTGRES_DB
           value: laalaa
-      - image: rabbitmq:3
+      - image: rabbitmq:3.6-management-alpine
         name: mq

--- a/kubernetes_deploy/development/deployment.yml
+++ b/kubernetes_deploy/development/deployment.yml
@@ -1,0 +1,45 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
+  name: laa-legal-adviser-api
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: laa-legal-adviser-api
+        env: staging
+        service_area: laa-get-access
+        service_team: cla-fala
+    spec:
+      containers:
+      - image: "<to be set by deploy_to_kubernetes>"
+        imagePullPolicy: Never
+        name: app
+        ports:
+        - containerPort: 80
+          name: http
+        env:
+        - name: LOG_LEVEL
+          value: INFO
+        - name: SECRET_KEY
+          value: secret
+        - name: DB_USERNAME
+          value: postgres
+        - name: DB_NAME
+          value: laalaa
+        - name: DB_HOST
+          value: 127.0.0.1
+        - name: DB_PORT
+          value: "5432"
+      - image: circleci/postgres:9.4-alpine-postgis
+        name: db
+        env:
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_DB
+          value: laalaa
+      - image: rabbitmq:3
+        name: mq

--- a/kubernetes_deploy/development/ingress.yml
+++ b/kubernetes_deploy/development/ingress.yml
@@ -1,0 +1,1 @@
+# Blank file, needs to exist because `deploy_to_kubernetes` expects it

--- a/kubernetes_deploy/development/service.yml
+++ b/kubernetes_deploy/development/service.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: laa-legal-adviser-api
+spec:
+  type: NodePort
+  ports:
+  - port: 8000
+    name: http
+    targetPort: 8000
+    nodePort: 31000
+  selector:
+    app: laa-legal-adviser-api


### PR DESCRIPTION
## What does this pull request do?

Adds configuration for deploying the app to a local (development) kubernetes cluster, with containers for the database and mq components (which would be external services in other environments).

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
