### PR TITLE
Add waiting for successful rollout of deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,11 @@ jobs:
           name: Deploy laalaa to staging
           command: |
             .circleci/deploy_to_kubernetes staging
+      - deploy:
+          name: Wait for deployment to finish
+          command: |
+            kubectl rollout status deployment.apps/laa-legal-adviser-api --timeout=5m
+            kubectl rollout status deployment.apps/laa-legal-adviser-api-worker --timeout=5m
       - slack/status
 
 workflows:


### PR DESCRIPTION
## What does this pull request do?

Adds waiting for a successful "rollout" (deployment) as per https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#deployment-status.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title" **Not applicable.**