### PR TITLE
LGA-645 - Run laalaa db migrations in a Job

### DIFF
--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -37,7 +37,15 @@ do
 done
 
 echo "Waiting for jobs"
-kubectl wait --for=condition=complete -f $COLLECT_STATIC -f $MIGRATE_DB --timeout=180s
+if ! kubectl wait --for=condition=complete -f $COLLECT_STATIC -f $MIGRATE_DB --timeout=180s ; then
+  echo "Failed pods:"
+  kubectl get pods --field-selector=status.phase=Failed
+  FIRST_POD=$(kubectl get pods --field-selector=status.phase=Failed -o=name | head -n 1)
+  echo "
+Logs for failed pod $FIRST_POD:"
+    kubectl logs $FIRST_POD
+  exit 1
+fi
 
 echo "Deploying app"
 # shellcheck disable=SC2002 # Useless cat, https://www.shellcheck.net/wiki/SC2002

--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -4,7 +4,6 @@ set -o pipefail
 ROOT=$(dirname "$0")
 NAMESPACE="$1"
 NAMESPACE_DIR="$ROOT/../kubernetes_deploy/$NAMESPACE"
-JOBS_RESOURCE="$NAMESPACE_DIR/jobs.yml"
 
 if [ -z "$NAMESPACE" ] ; then
   printf "usage: deploy_to_kubernetes namespace\n"
@@ -22,16 +21,23 @@ if [ -z "$ECR_DEPLOY_IMAGE" ] ; then
 fi
 
 echo "Deploying $ECR_DEPLOY_IMAGE to $NAMESPACE..."
-echo "Deleting old jobs"
-kubectl delete -f $JOBS_RESOURCE --ignore-not-found
 
 echo "Running jobs"
-cat $JOBS_RESOURCE| \
-  kubectl set image app="$ECR_DEPLOY_IMAGE" --filename=/dev/stdin --local --output=yaml | \
-  kubectl annotate kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --filename=/dev/stdin --local --output=yaml | \
-  kubectl apply --record=false \
-    --filename=/dev/stdin
-kubectl wait --for=condition=complete -f $JOBS_RESOURCE --timeout=180s
+COLLECT_STATIC=$NAMESPACE_DIR/collect-static-job.yml 
+MIGRATE_DB=$NAMESPACE_DIR/migrate-db-job.yml 
+
+for JOB in $COLLECT_STATIC $MIGRATE_DB
+do
+  echo "Running $JOB"
+  kubectl delete -f $JOB --ignore-not-found
+  cat $JOB| \
+    kubectl set image app="$ECR_DEPLOY_IMAGE" --filename=/dev/stdin --local --output=yaml | \
+    kubectl annotate kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --filename=/dev/stdin --local --output=yaml | \
+    kubectl apply --record=false --filename=/dev/stdin
+done
+
+echo "Waiting for jobs"
+kubectl wait --for=condition=complete -f $COLLECT_STATIC -f $MIGRATE_DB --timeout=180s
 
 echo "Deploying app"
 # shellcheck disable=SC2002 # Useless cat, https://www.shellcheck.net/wiki/SC2002

--- a/kubernetes_deploy/development/collect-static-job.yml
+++ b/kubernetes_deploy/development/collect-static-job.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: laa-legal-adviser-collect-static
+      name: laa-legal-adviser-api-collect-static
     spec:
       restartPolicy: Never
       containers:

--- a/kubernetes_deploy/development/migrate-db-job.yml
+++ b/kubernetes_deploy/development/migrate-db-job.yml
@@ -16,8 +16,6 @@ spec:
         imagePullPolicy: Never
         command: ["python", "manage.py", "migrate", "--noinput"]
         env:
-          - name: SECRET_KEY
-            value: secret
           - name: DB_USERNAME
             value: postgres
           - name: DB_NAME

--- a/kubernetes_deploy/development/migrate-db-job.yml
+++ b/kubernetes_deploy/development/migrate-db-job.yml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
+  name: laa-legal-adviser-api-migrate-db
+spec:
+  template:
+    metadata:
+      name: laa-legal-adviser-api-migrate-db
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: app
+        image: "<to be set by deploy_to_kubernetes>"
+        imagePullPolicy: Never
+        command: ["python", "manage.py", "migrate", "--noinput"]
+        env:
+          - name: SECRET_KEY
+            value: secret
+          - name: DB_USERNAME
+            value: postgres
+          - name: DB_NAME
+            value: laalaa
+          - name: DB_HOST
+            value: laa-legal-adviser-api-shared-services
+

--- a/kubernetes_deploy/staging/collect-static-job.yml
+++ b/kubernetes_deploy/staging/collect-static-job.yml
@@ -8,7 +8,7 @@ spec:
   ttlSecondsAfterFinished: 120
   template:
     metadata:
-      name: laa-legal-adviser-collect-static
+      name: laa-legal-adviser-api-collect-static
     spec:
       restartPolicy: Never
       containers:

--- a/kubernetes_deploy/staging/migrate-db-job.yml
+++ b/kubernetes_deploy/staging/migrate-db-job.yml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
+  name: laa-legal-adviser-api-migrate-db
+spec:
+  ttlSecondsAfterFinished: 120
+  template:
+    metadata:
+      name: laa-legal-adviser-api-migrate-db
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: app
+        image: "<to be set by deploy_to_kubernetes>"
+        command: ["python", "manage.py", "migrate", "--noinput"]
+        env:
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret-key
+              key: SECRET_KEY
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: db
+              key: user
+        - name: DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: db
+              key: name
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: db
+              key: password
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: db
+              key: host
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: db
+              key: port


### PR DESCRIPTION
## What does this pull request do?
Builds on #121 
Adds a Job to run database migrations
Renames the existing Job file to reflect that we're not putting multiple Job resources in one file as previously planned, as that didn't work well with how we apply them

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
