### PR TITLE
LGA-666 - Set livenessProbe and readinessProbe for queue worker pods

### DIFF
--- a/kubernetes_deploy/development/queue_worker_deployment.yml
+++ b/kubernetes_deploy/development/queue_worker_deployment.yml
@@ -27,13 +27,13 @@ spec:
         args: ["docker/run_worker.sh"]
         readinessProbe:
           exec:
-            command: ["docker/ping.sh"]
+            command: ["docker/ping_services.sh"]
           initialDelaySeconds: 5
           timeoutSeconds: 1
           periodSeconds: 10
         livenessProbe:
           exec:
-            command: ["docker/ping.sh"]
+            command: ["docker/ping_services.sh"]
           initialDelaySeconds: 10
           timeoutSeconds: 1
           periodSeconds: 10

--- a/kubernetes_deploy/production/queue_worker_deployment.yml
+++ b/kubernetes_deploy/production/queue_worker_deployment.yml
@@ -24,6 +24,18 @@ spec:
       - image: "<to be set by deploy_to_kubernetes>"
         name: worker
         args: ["docker/run_worker.sh"]
+        readinessProbe:
+          exec:
+            command: ["docker/ping_services.sh"]
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+        livenessProbe:
+          exec:
+            command: ["docker/ping_services.sh"]
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+          periodSeconds: 10
         env:
         - name: WORKER_APP_CONCURRENCY
           value: "2"

--- a/kubernetes_deploy/staging/queue_worker_deployment.yml
+++ b/kubernetes_deploy/staging/queue_worker_deployment.yml
@@ -24,6 +24,18 @@ spec:
       - image: "<to be set by deploy_to_kubernetes>"
         name: worker
         args: ["docker/run_worker.sh"]
+        readinessProbe:
+          exec:
+            command: ["docker/ping_services.sh"]
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+        livenessProbe:
+          exec:
+            command: ["docker/ping_services.sh"]
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+          periodSeconds: 10
         env:
         - name: WORKER_APP_CONCURRENCY
           value: "2"


### PR DESCRIPTION
## What does this pull request do?
Sets the liveness and readiness probes for the staging and production queue worker pods
Fixes the liveness and readiness probes for the development queue worker pods

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
