### PR TITLE
LGA-708 - Remove celery heartbeat and make it quieter

### DIFF
--- a/docker/run_worker.sh
+++ b/docker/run_worker.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -e
-exec ./manage.py celery worker -A laalaa --concurrency=$WORKER_APP_CONCURRENCY --loglevel=$LOG_LEVEL
+exec ./manage.py celery worker -A laalaa --concurrency=$WORKER_APP_CONCURRENCY --loglevel=$LOG_LEVEL --without-gossip --without-mingle --without-heartbeat


### PR DESCRIPTION
These are the recommended settings for cloudamqp.com, to avoid burning
through usage limits with heartbeats and other meta tasks. Apparently
the way they manage connections does not benefit from having these.

This code has already been merged into another feature branch, but that hasn't reached `master` yet, so this PR is to put this change straight into `master` without having to wait.

## What does this pull request do?

Required.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
