### PR TITLE
LGA-820 - Switch to Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ near that point.
 
 :memo: If you are using Docker to provide RabbitMQ, it's preferable to use one with management interface enabled:
 
-    docker run --detach --publish 5672:5672 --publish 15672:15672 rabbitmq:3.7-management-alpine
+    docker run --detach --publish 6379:6379 redis:4-alpine
 
 As a convenience, a `docker-compose.yml` specifies these dependendencies and can be run with:
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ cp laalaa/settings/local.py.example laalaa/settings/local.py
 
 | Service | Command |
 | --- | --- |
-| API | `python manage.py runserver` |
-| Worker | `python manage.py celery worker` |
+| API | `./manage.py runserver` |
+| Worker | `celery worker` |
 
 There is a Django admin site which allows importing and editing the database of legal advisers.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     image: jwilder/dockerize
     command: >
       -wait tcp://db:5432 -timeout 30s
-      -wait tcp://rabbitmq:5672 -timeout 30s
+      -wait tcp://redis:6379 -timeout 30s
     depends_on:
       - db
-      - rabbitmq
+      - redis
 
   start_app:
     image: jwilder/dockerize
@@ -28,15 +28,11 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_DB: laalaa
 
-  rabbitmq:
-    image: rabbitmq:3.7-management-alpine
+  redis:
+    image: redis:4-alpine
     ports:
-      - target: 5672
-        published: 5672
-        protocol: tcp
-        mode: host
-      - target: 15672
-        published: 15672
+      - target: 6379
+        published: 6379
         protocol: tcp
         mode: host
 
@@ -50,10 +46,9 @@ services:
         mode: host
     environment:
       DB_USERNAME: postgres
-      DB_PASSWORD: 
+      DB_PASSWORD:
       DB_HOST: db
       DB_PORT: 5432
       DB_NAME: laalaa
-      HOST_IP: rabbitmq
-      RABBITMQ_USER: guest
-      RABBITMQ_PASS: guest
+      HOST_IP: redis
+      CELERY_BROKER_URL: redis://redis:6379

--- a/docker/run_worker.sh
+++ b/docker/run_worker.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -e
-exec celery worker -A laalaa --concurrency=$WORKER_APP_CONCURRENCY --loglevel=$LOG_LEVEL
+exec celery worker -A laalaa --concurrency=${WORKER_APP_CONCURRENCY:-4} --loglevel=${LOG_LEVEL:-INFO}

--- a/docker/run_worker.sh
+++ b/docker/run_worker.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -e
-exec ./manage.py celery worker -A laalaa --concurrency=$WORKER_APP_CONCURRENCY --loglevel=$LOG_LEVEL --without-gossip --without-mingle --without-heartbeat
+exec celery worker -A laalaa --concurrency=$WORKER_APP_CONCURRENCY --loglevel=$LOG_LEVEL

--- a/kubernetes_deploy/development/deployment.yml
+++ b/kubernetes_deploy/development/deployment.yml
@@ -50,4 +50,4 @@ spec:
         - name: DB_PORT
           value: "5432"
         - name: CELERY_BROKER_URL
-          value: "amqp://guest:guest@laa-legal-adviser-api-shared-services:5672//"
+          value: "redis://laa-legal-adviser-api-shared-services:6379"

--- a/kubernetes_deploy/development/deployment.yml
+++ b/kubernetes_deploy/development/deployment.yml
@@ -49,5 +49,5 @@ spec:
           value: laa-legal-adviser-api-shared-services
         - name: DB_PORT
           value: "5432"
-        - name: BROKER_URL
+        - name: CELERY_BROKER_URL
           value: "amqp://guest:guest@laa-legal-adviser-api-shared-services:5672//"

--- a/kubernetes_deploy/development/deployment.yml
+++ b/kubernetes_deploy/development/deployment.yml
@@ -49,5 +49,5 @@ spec:
           value: laa-legal-adviser-api-shared-services
         - name: DB_PORT
           value: "5432"
-        - name: AMQP_BROKER_URL
+        - name: BROKER_URL
           value: "amqp://guest:guest@laa-legal-adviser-api-shared-services:5672//"

--- a/kubernetes_deploy/development/queue_worker_deployment.yml
+++ b/kubernetes_deploy/development/queue_worker_deployment.yml
@@ -52,5 +52,5 @@ spec:
           value: laa-legal-adviser-api-shared-services
         - name: DB_PORT
           value: "5432"
-        - name: AMQP_BROKER_URL
+        - name: BROKER_URL
           value: "amqp://guest:guest@laa-legal-adviser-api-shared-services:5672//"

--- a/kubernetes_deploy/development/queue_worker_deployment.yml
+++ b/kubernetes_deploy/development/queue_worker_deployment.yml
@@ -52,5 +52,5 @@ spec:
           value: laa-legal-adviser-api-shared-services
         - name: DB_PORT
           value: "5432"
-        - name: BROKER_URL
+        - name: CELERY_BROKER_URL
           value: "amqp://guest:guest@laa-legal-adviser-api-shared-services:5672//"

--- a/kubernetes_deploy/development/queue_worker_deployment.yml
+++ b/kubernetes_deploy/development/queue_worker_deployment.yml
@@ -53,4 +53,4 @@ spec:
         - name: DB_PORT
           value: "5432"
         - name: CELERY_BROKER_URL
-          value: "amqp://guest:guest@laa-legal-adviser-api-shared-services:5672//"
+          value: "redis://laa-legal-adviser-api-shared-services:6379"

--- a/kubernetes_deploy/development/service.yml
+++ b/kubernetes_deploy/development/service.yml
@@ -23,10 +23,10 @@ spec:
     tier: shared-services
   ports:
     - protocol: TCP
-      name: mq-5432
+      name: postgresql
       port: 5432
       targetPort: 5432
     - protocol: TCP
-      name: mq-5672
-      port: 5672
-      targetPort: 5672
+      name: redis
+      port: 6379
+      targetPort: 6379

--- a/kubernetes_deploy/development/shared_services_deployment.yml
+++ b/kubernetes_deploy/development/shared_services_deployment.yml
@@ -27,5 +27,5 @@ spec:
           value: postgres
         - name: POSTGRES_DB
           value: laalaa
-      - image: rabbitmq:3.6-management-alpine
-        name: amq
+      - image: redis:4-alpine
+        name: redis

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -101,7 +101,7 @@ spec:
             secretKeyRef:
               name: s3
               key: region
-        - name: AMQP_BROKER_URL
+        - name: BROKER_URL
           valueFrom:
             secretKeyRef:
               name: amqp

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -101,7 +101,7 @@ spec:
             secretKeyRef:
               name: s3
               key: region
-        - name: BROKER_URL
+        - name: CELERY_BROKER_URL
           valueFrom:
             secretKeyRef:
               name: amqp

--- a/kubernetes_deploy/production/queue_worker_deployment.yml
+++ b/kubernetes_deploy/production/queue_worker_deployment.yml
@@ -76,7 +76,7 @@ spec:
             secretKeyRef:
               name: db
               key: port
-        - name: AMQP_BROKER_URL
+        - name: BROKER_URL
           valueFrom:
             secretKeyRef:
               name: amqp

--- a/kubernetes_deploy/production/queue_worker_deployment.yml
+++ b/kubernetes_deploy/production/queue_worker_deployment.yml
@@ -76,7 +76,7 @@ spec:
             secretKeyRef:
               name: db
               key: port
-        - name: BROKER_URL
+        - name: CELERY_BROKER_URL
           valueFrom:
             secretKeyRef:
               name: amqp

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -99,7 +99,7 @@ spec:
             secretKeyRef:
               name: s3
               key: region
-        - name: AMQP_BROKER_URL
+        - name: BROKER_URL
           valueFrom:
             secretKeyRef:
               name: celery-broker

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -104,3 +104,5 @@ spec:
             secretKeyRef:
               name: celery-broker
               key: url
+        - name: CELERY_BROKER_USE_SSL
+          value: "true"

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -99,7 +99,7 @@ spec:
             secretKeyRef:
               name: s3
               key: region
-        - name: BROKER_URL
+        - name: CELERY_BROKER_URL
           valueFrom:
             secretKeyRef:
               name: celery-broker

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -102,5 +102,5 @@ spec:
         - name: AMQP_BROKER_URL
           valueFrom:
             secretKeyRef:
-              name: amqp
+              name: celery-broker
               key: url

--- a/kubernetes_deploy/staging/queue_worker_deployment.yml
+++ b/kubernetes_deploy/staging/queue_worker_deployment.yml
@@ -38,7 +38,7 @@ spec:
           periodSeconds: 10
         env:
         - name: WORKER_APP_CONCURRENCY
-          value: "2"
+          value: "8"
         - name: LOG_LEVEL
           value: INFO
         - name: SECRET_KEY

--- a/kubernetes_deploy/staging/queue_worker_deployment.yml
+++ b/kubernetes_deploy/staging/queue_worker_deployment.yml
@@ -76,7 +76,7 @@ spec:
             secretKeyRef:
               name: db
               key: port
-        - name: AMQP_BROKER_URL
+        - name: BROKER_URL
           valueFrom:
             secretKeyRef:
               name: celery-broker

--- a/kubernetes_deploy/staging/queue_worker_deployment.yml
+++ b/kubernetes_deploy/staging/queue_worker_deployment.yml
@@ -79,5 +79,5 @@ spec:
         - name: AMQP_BROKER_URL
           valueFrom:
             secretKeyRef:
-              name: amqp
+              name: celery-broker
               key: url

--- a/kubernetes_deploy/staging/queue_worker_deployment.yml
+++ b/kubernetes_deploy/staging/queue_worker_deployment.yml
@@ -81,3 +81,5 @@ spec:
             secretKeyRef:
               name: celery-broker
               key: url
+        - name: CELERY_BROKER_USE_SSL
+          value: "true"

--- a/kubernetes_deploy/staging/queue_worker_deployment.yml
+++ b/kubernetes_deploy/staging/queue_worker_deployment.yml
@@ -76,7 +76,7 @@ spec:
             secretKeyRef:
               name: db
               key: port
-        - name: BROKER_URL
+        - name: CELERY_BROKER_URL
           valueFrom:
             secretKeyRef:
               name: celery-broker

--- a/laalaa/apps/advisers/tasks.py
+++ b/laalaa/apps/advisers/tasks.py
@@ -8,7 +8,7 @@ import time
 import tempfile
 import xlrd
 
-from celery.task import TaskSet
+from celery import group
 from django.utils.text import slugify
 from celery import Task
 from django.core.cache import cache
@@ -147,8 +147,8 @@ class ProgressiveAdviserImport(Task):
         for chunk in chunks():
             t = GeocoderTask().subtask(args=(chunk,))
             tasks.append(t)
-        ts = TaskSet(tasks=tasks)
-        res = ts.apply_async()
+        ts = group(tasks)
+        res = ts()
 
         task_counts = {}
         task_errors = {}

--- a/laalaa/apps/advisers/tasks.py
+++ b/laalaa/apps/advisers/tasks.py
@@ -18,6 +18,7 @@ from django.db import connection
 
 from . import models
 from . import geocoder
+from laalaa.celery import app
 
 
 logging.basicConfig(filename="adviser_import.log", level=logging.WARNING)
@@ -71,6 +72,8 @@ class StrippedDict(dict):
 
 
 class GeocoderTask(Task):
+    name = 'advisers.tasks.GeocoderTask'
+
     def __init__(self):
         self.errors = []
 
@@ -99,6 +102,8 @@ class GeocoderTask(Task):
 
 
 class ProgressiveAdviserImport(Task):
+    name = 'advisers.tasks.ProgressiveAdviserImport'
+
     worksheet_names = (
         "LOCAL ADVICE ORG",
         "OFFICE LOCATION",
@@ -517,3 +522,7 @@ class ProgressiveAdviserImport(Task):
                         off.account_number = cri.account_number AND
                         cat.code = cri.crime_category_code"""
         )
+
+
+app.register_task(GeocoderTask())
+app.register_task(ProgressiveAdviserImport())

--- a/laalaa/celery.py
+++ b/laalaa/celery.py
@@ -15,9 +15,8 @@ from django.conf import settings  # noqa
 
 app = Celery("laalaa")
 
-# Using a string here means the worker will not have to
-# pickle the object when using Windows.
-app.config_from_object("django.conf:settings")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 client = None

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = (
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.gis",
+    "django_celery_results",
     "rest_framework",
     "rest_framework_gis",
     "advisers",
@@ -150,7 +151,9 @@ CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"
 CACHE_MIDDLEWARE_SECONDS = 3600
 
 CELERY_ACCEPT_CONTENT = ["pickle", "json", "msgpack"]
-CELERY_RESULT_BACKEND = "celery.backends.database:DatabaseBackend"
+
+CELERY_RESULT_BACKEND = "django-db"
+
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL")
 if not CELERY_BROKER_URL:
     CELERY_BROKER_URL = "amqp://%s:%s@%s//" % (

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -53,8 +53,6 @@ INSTALLED_APPS = (
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.gis",
-    "kombu.transport.django",
-    "djcelery",
     "rest_framework",
     "rest_framework_gis",
     "advisers",
@@ -152,7 +150,7 @@ CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"
 CACHE_MIDDLEWARE_SECONDS = 3600
 
 CELERY_ACCEPT_CONTENT = ["pickle", "json", "msgpack"]
-CELERY_RESULT_BACKEND = "djcelery.backends.database:DatabaseBackend"
+CELERY_RESULT_BACKEND = "celery.backends.database:DatabaseBackend"
 BROKER_URL = os.environ.get("BROKER_URL")
 if not BROKER_URL:
     BROKER_URL = "amqp://%s:%s@%s//" % (

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -153,7 +153,7 @@ CACHE_MIDDLEWARE_SECONDS = 3600
 
 CELERY_ACCEPT_CONTENT = ["pickle", "json", "msgpack"]
 CELERY_RESULT_BACKEND = "djcelery.backends.database:DatabaseBackend"
-BROKER_URL = os.environ.get("AMQP_BROKER_URL")
+BROKER_URL = os.environ.get("BROKER_URL")
 if not BROKER_URL:
     BROKER_URL = "amqp://%s:%s@%s//" % (
         os.environ.get("RABBITMQ_USER", "guest"),

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -129,8 +129,8 @@ FILE_UPLOAD_MAX_MEMORY_SIZE = 0
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
-if os.environ.get("STATIC_FILES_BACKEND") == 's3':
-    STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+if os.environ.get("STATIC_FILES_BACKEND") == "s3":
+    STATICFILES_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 
 AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_STORAGE_BUCKET_NAME")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
@@ -155,11 +155,20 @@ CELERY_ACCEPT_CONTENT = ["pickle", "json", "msgpack"]
 
 CELERY_RESULT_BACKEND = "django-db"
 
-CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379")
+if "RABBITMQ_USER" in os.environ:
+    # Remove entire block when migration to Kubernetes is done
+    CELERY_BROKER_URL = "amqp://%s:%s@%s//" % (
+        os.environ.get("RABBITMQ_USER", "guest"),
+        os.environ.get("RABBITMQ_PASS", "guest"),
+        os.environ.get("RABBITMQ_HOST", os.environ.get("HOST_IP", "127.0.0.1")),
+    )
+else:
 
-CELERY_BROKER_USE_SSL = os.environ.get("CELERY_BROKER_USE_SSL", None)
-if CELERY_BROKER_USE_SSL:
-    CELERY_BROKER_USE_SSL = {"ssl_cert_reqs": ssl.CERT_NONE}
+    CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379")
+
+    CELERY_BROKER_USE_SSL = os.environ.get("CELERY_BROKER_USE_SSL", None)
+    if CELERY_BROKER_USE_SSL:
+        CELERY_BROKER_USE_SSL = {"ssl_cert_reqs": ssl.CERT_NONE}
 
 TEMP_DIRECTORY = root("tmp")
 

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -154,13 +154,7 @@ CELERY_ACCEPT_CONTENT = ["pickle", "json", "msgpack"]
 
 CELERY_RESULT_BACKEND = "django-db"
 
-CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL")
-if not CELERY_BROKER_URL:
-    CELERY_BROKER_URL = "amqp://%s:%s@%s//" % (
-        os.environ.get("RABBITMQ_USER", "guest"),
-        os.environ.get("RABBITMQ_PASS", "guest"),
-        os.environ.get("RABBITMQ_HOST", os.environ.get("HOST_IP", "127.0.0.1")),
-    )
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379")
 
 TEMP_DIRECTORY = root("tmp")
 

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 import os
 from os.path import join, abspath, dirname
 import sys
+import ssl
 
 
 def here(*x):
@@ -155,6 +156,10 @@ CELERY_ACCEPT_CONTENT = ["pickle", "json", "msgpack"]
 CELERY_RESULT_BACKEND = "django-db"
 
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379")
+
+CELERY_BROKER_USE_SSL = os.environ.get("CELERY_BROKER_USE_SSL", None)
+if CELERY_BROKER_USE_SSL:
+    CELERY_BROKER_USE_SSL = {"ssl_cert_reqs": ssl.CERT_NONE}
 
 TEMP_DIRECTORY = root("tmp")
 

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -151,9 +151,9 @@ CACHE_MIDDLEWARE_SECONDS = 3600
 
 CELERY_ACCEPT_CONTENT = ["pickle", "json", "msgpack"]
 CELERY_RESULT_BACKEND = "celery.backends.database:DatabaseBackend"
-BROKER_URL = os.environ.get("BROKER_URL")
-if not BROKER_URL:
-    BROKER_URL = "amqp://%s:%s@%s//" % (
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL")
+if not CELERY_BROKER_URL:
+    CELERY_BROKER_URL = "amqp://%s:%s@%s//" % (
         os.environ.get("RABBITMQ_USER", "guest"),
         os.environ.get("RABBITMQ_PASS", "guest"),
         os.environ.get("RABBITMQ_HOST", os.environ.get("HOST_IP", "127.0.0.1")),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 boto3==1.9.159
-celery==3.1.25
+celery[redis]==3.1.25
 django-celery==3.2.2
 django-filter==1.1
 django==1.11.20

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,6 @@
 boto3==1.9.159
 celery[redis]==4.3.0
+django-celery-results==1.1.2
 django-filter==1.1
 django==1.11.20
 django-storages==1.7.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,6 @@
 boto3==1.9.159
 celery[redis]==3.1.25
+redis==2.10.6
 django-celery==3.2.2
 django-filter==1.1
 django==1.11.20

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,5 @@
 boto3==1.9.159
-celery[redis]==3.1.25
-redis==2.10.6
-django-celery==3.2.2
+celery[redis]==4.3.0
 django-filter==1.1
 django==1.11.20
 django-storages==1.7.1
@@ -14,3 +12,6 @@ requests==2.19.1
 uwsgi==2.0.17.1
 xlrd==0.9.3
 django-moj-irat>=0.4
+
+# locks for Python 2.7
+more-itertools==5.0.0

--- a/setup_postgres.sh
+++ b/setup_postgres.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+set -e
 database="laalaa"
 psql $database --command='SELECT 1' >/dev/null 2>/dev/null || createdb --echo "$database"
 psql $database --command='CREATE EXTENSION IF NOT EXISTS postgis;'


### PR DESCRIPTION
## What does this pull request do?

Reconfigures the application to use Redis as the Celery broker.

Cloud Platform staging namespace has been provisioned with Amazon ElastiCache for Redis to match this change:

- https://github.com/ministryofjustice/cloud-platform-environments/pull/1182
- https://github.com/ministryofjustice/cloud-platform-environments/pull/1184

## Any other changes that would benefit highlighting?

Please review commit-by-commit to review the intent in the commit messages.

Performance with node_type cache.t2.micro
redis-cp: 10 minutes with 8 workers for 4700 records, 470/minute
amqp-td: 2.5 minutes with 8 workers for 4700 records, 1880/minute

redis-cp is 4x slower than amqp-td but at this stage we are trying to get the application to work.
Further work is required to address performance when needed

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title".
- [x] 🚨In this form, this change is **incompatible** with template-deploy. Template-deploy needs to be reconfigured to use `CELERY_BROKER_URL` for RabbitMQ (and installing the necessary libraries) for it to work.
- [ ] ⚠️The production Cloud Platform namespace needs an ElastiCache instance.