### PR TITLE
LGA-849 - Update production config to use redis celery broker

### DIFF
--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -104,5 +104,7 @@ spec:
         - name: CELERY_BROKER_URL
           valueFrom:
             secretKeyRef:
-              name: amqp
+              name: celery-broker
               key: url
+        - name: CELERY_BROKER_USE_SSL
+          value: "true"

--- a/kubernetes_deploy/production/queue_worker_deployment.yml
+++ b/kubernetes_deploy/production/queue_worker_deployment.yml
@@ -38,7 +38,7 @@ spec:
           periodSeconds: 10
         env:
         - name: WORKER_APP_CONCURRENCY
-          value: "2"
+          value: "8"
         - name: LOG_LEVEL
           value: INFO
         - name: SECRET_KEY
@@ -79,5 +79,7 @@ spec:
         - name: CELERY_BROKER_URL
           valueFrom:
             secretKeyRef:
-              name: amqp
+              name: celery-broker
               key: url
+        - name: CELERY_BROKER_USE_SSL
+          value: "true"


### PR DESCRIPTION
## What does this pull request do?

Update production config to use redis celery broker

## Any other changes that would benefit highlighting?
Cloud Platform staging namespace has been provisioned with Amazon ElastiCache for Redis to match this change:

https://github.com/ministryofjustice/cloud-platform-environments/pull/1453

Performance with node_type cache.t2.medium
redis-cp: 10 minutes with 8 workers for 4700 records, 470/minute

Strangely performance did not improve from staging (https://github.com/ministryofjustice/laa-legal-adviser-api/pull/136) even when running on a more powerful node_type

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
- [x] Remove changes to make testing easier from .circle/config.yml

