### PR TITLE
Downgrade kombu from 4.6.5 to 4.6.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,6 +13,8 @@ requests==2.19.1
 uwsgi==2.0.17.1
 xlrd==0.9.3
 django-moj-irat>=0.4
+# https://github.com/celery/kombu/issues/1063
+kombu==4.6.3
 
 # locks for Python 2.7
 more-itertools==5.0.0


### PR DESCRIPTION
## What does this pull request do?

Downgrade kombu from 4.6.5 to 4.6.3 to fix issue with redis keys getting evicted which resulted in the following error:

> Control command error: OperationalError(u"\nCannot route message for exchange u'reply.celery.pidbox': Table empty or key no longer exists.\nProbably the key (u'_kombu.binding.reply.celery.pidbox') has been removed from the Redis database.\n",)


## Any other changes that would benefit highlighting?

Fixed adopted from https://github.com/celery/kombu/issues/1063

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
- [x] Tested on template-deploy
- [x] Tested on cloud platforms staging
