### PR TITLE
LGA-820, LGA-849: Load namespaced Celery configuration in healthcheck

### DIFF
--- a/laalaa/apps/advisers/healthchecks.py
+++ b/laalaa/apps/advisers/healthchecks.py
@@ -6,7 +6,7 @@ def get_stats():
     from celery import Celery
 
     app = Celery("laalaa")
-    app.config_from_object("django.conf:settings")
+    app.config_from_object("django.conf:settings", namespace="CELERY")
     return app.control.inspect().stats()
 
 


### PR DESCRIPTION
## What does this pull request do?

Configures the `/healthcheck.json` URL to use the new configuration style of Celery 4 under Django.

## Any other changes that would benefit highlighting?

In bed52d9c60b00be751a6a9a6fc78b333fc5bccf6, I had to change the configuration to be compatible with Django. I completely missed this part.

Unfortunately, the test for this module starts with mocking the `get_stats()` function, where this code exists, so I am at loss at how to test this.

For now, I think we can expose `/healthcheck.json` on the staging environment which would have helped detect this problem. In the long-term, we will use a separate healthcheck for the worker processes.

There is still the question whether the "webapp" can connect to the "broker" which I feel could be tackled by this app's healthcheck.

Thoughts for later, I suppose.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
