### PR TITLE
LGA-649 - Use DATABASE_URL connection string

### DIFF
--- a/docker/setup_postgres.sh
+++ b/docker/setup_postgres.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-PGPASSWORD=$DB_PASSWORD /usr/bin/psql --host $DB_HOST -U $DB_USERNAME $DB_NAME -c 'CREATE EXTENSION IF NOT EXISTS postgis;'
-PGPASSWORD=$DB_PASSWORD /usr/bin/psql --host $DB_HOST -U $DB_USERNAME $DB_NAME -c 'CREATE EXTENSION IF NOT EXISTS postgis_topology;'
+/usr/bin/psql "${DATABASE_URL/postgis/postgres}" -c 'CREATE EXTENSION IF NOT EXISTS postgis;'
+/usr/bin/psql "${DATABASE_URL/postgis/postgres}" -c 'CREATE EXTENSION IF NOT EXISTS postgis_topology;'

--- a/kubernetes_deploy/development/deployment.yml
+++ b/kubernetes_deploy/development/deployment.yml
@@ -41,13 +41,7 @@ spec:
         env:
         - name: LOG_LEVEL
           value: INFO
-        - name: DB_USERNAME
-          value: postgres
-        - name: DB_NAME
-          value: laalaa
-        - name: DB_HOST
-          value: laa-legal-adviser-api-shared-services
-        - name: DB_PORT
-          value: "5432"
+        - name: DATABASE_URL
+          value: "postgres://postgres@laa-legal-adviser-api-shared-services:5432/laalaa"
         - name: CELERY_BROKER_URL
           value: "redis://laa-legal-adviser-api-shared-services:6379"

--- a/kubernetes_deploy/development/migrate-db-job.yml
+++ b/kubernetes_deploy/development/migrate-db-job.yml
@@ -21,9 +21,5 @@ spec:
         imagePullPolicy: Never
         command: ["python", "manage.py", "migrate", "--noinput"]
         env:
-          - name: DB_USERNAME
-            value: postgres
-          - name: DB_NAME
-            value: laalaa
-          - name: DB_HOST
-            value: laa-legal-adviser-api-shared-services
+          - name: DATABASE_URL
+            value: "postgres://postgres@laa-legal-adviser-api-shared-services:5432/laalaa"

--- a/kubernetes_deploy/development/queue_worker_deployment.yml
+++ b/kubernetes_deploy/development/queue_worker_deployment.yml
@@ -44,13 +44,7 @@ spec:
           value: INFO
         - name: LOG_LEVEL
           value: INFO
-        - name: DB_USERNAME
-          value: postgres
-        - name: DB_NAME
-          value: laalaa
-        - name: DB_HOST
-          value: laa-legal-adviser-api-shared-services
-        - name: DB_PORT
-          value: "5432"
+        - name: DATABASE_URL
+          value: "postgres://postgres@laa-legal-adviser-api-shared-services:5432/laalaa"
         - name: CELERY_BROKER_URL
           value: "redis://laa-legal-adviser-api-shared-services:6379"

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -52,31 +52,11 @@ spec:
             secretKeyRef:
               name: sentry
               key: dsn
-        - name: DB_USERNAME
+        - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
               name: db
-              key: user
-        - name: DB_NAME
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: name
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: password
-        - name: DB_HOST
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: host
-        - name: DB_PORT
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: port
+              key: url
         - name: STATIC_FILES_BACKEND
           value: s3
         - name: AWS_STORAGE_BUCKET_NAME

--- a/kubernetes_deploy/production/migrate-db-job.yml
+++ b/kubernetes_deploy/production/migrate-db-job.yml
@@ -27,28 +27,8 @@ spec:
             secretKeyRef:
               name: secret-key
               key: SECRET_KEY
-        - name: DB_USERNAME
+        - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
               name: db
-              key: user
-        - name: DB_NAME
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: name
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: password
-        - name: DB_HOST
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: host
-        - name: DB_PORT
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: port
+              key: url

--- a/kubernetes_deploy/production/queue_worker_deployment.yml
+++ b/kubernetes_deploy/production/queue_worker_deployment.yml
@@ -51,31 +51,11 @@ spec:
             secretKeyRef:
               name: sentry
               key: dsn
-        - name: DB_USERNAME
+        - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
               name: db
-              key: user
-        - name: DB_NAME
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: name
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: password
-        - name: DB_HOST
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: host
-        - name: DB_PORT
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: port
+              key: url
         - name: CELERY_BROKER_URL
           valueFrom:
             secretKeyRef:

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -50,31 +50,11 @@ spec:
             secretKeyRef:
               name: sentry
               key: dsn
-        - name: DB_USERNAME
+        - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
               name: db
-              key: user
-        - name: DB_NAME
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: name
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: password
-        - name: DB_HOST
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: host
-        - name: DB_PORT
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: port
+              key: url
         - name: STATIC_FILES_BACKEND
           value: s3
         - name: AWS_STORAGE_BUCKET_NAME

--- a/kubernetes_deploy/staging/migrate-db-job.yml
+++ b/kubernetes_deploy/staging/migrate-db-job.yml
@@ -25,28 +25,8 @@ spec:
             secretKeyRef:
               name: secret-key
               key: SECRET_KEY
-        - name: DB_USERNAME
+        - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
               name: db
-              key: user
-        - name: DB_NAME
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: name
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: password
-        - name: DB_HOST
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: host
-        - name: DB_PORT
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: port
+              key: url

--- a/kubernetes_deploy/staging/queue_worker_deployment.yml
+++ b/kubernetes_deploy/staging/queue_worker_deployment.yml
@@ -51,31 +51,11 @@ spec:
             secretKeyRef:
               name: sentry
               key: dsn
-        - name: DB_USERNAME
+        - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
               name: db
-              key: user
-        - name: DB_NAME
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: name
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: password
-        - name: DB_HOST
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: host
-        - name: DB_PORT
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: port
+              key: url
         - name: CELERY_BROKER_URL
           valueFrom:
             secretKeyRef:

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -100,7 +100,7 @@ TEMPLATES = [
 
 DATABASES = {
     "default": dj_database_url.config(
-        default="postgres://postgres@127.0.0.1:5432/laalaa", engine="django.contrib.gis.db.backends.postgis"
+        default="postgis://postgres@127.0.0.1:5432/laalaa", engine="django.contrib.gis.db.backends.postgis"
     )
 }
 

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -13,6 +13,7 @@ import os
 from os.path import join, abspath, dirname
 import sys
 import ssl
+import dj_database_url
 
 
 def here(*x):
@@ -98,14 +99,9 @@ TEMPLATES = [
 # https://docs.djangoproject.com/en/1.7/ref/settings/#databases
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.contrib.gis.db.backends.postgis",
-        "NAME": os.environ.get("DB_NAME", "laalaa"),
-        "USER": os.environ.get("DB_USERNAME", os.environ.get("DB_NAME", "postgres")),
-        "PASSWORD": os.environ.get("DB_PASSWORD", ""),
-        "HOST": os.environ.get("DB_HOST", "127.0.0.1"),
-        "PORT": os.environ.get("DB_PORT", "5432"),
-    }
+    "default": dj_database_url.config(
+        default="postgres://postgres@127.0.0.1:5432/laalaa", engine="django.contrib.gis.db.backends.postgis"
+    )
 }
 
 # Internationalization

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -100,7 +100,9 @@ TEMPLATES = [
 
 DATABASES = {
     "default": dj_database_url.config(
-        default="postgis://postgres@127.0.0.1:5432/laalaa", engine="django.contrib.gis.db.backends.postgis"
+        env="DATABASE_URL",
+        default="postgis://postgres@127.0.0.1:5432/laalaa",
+        engine="django.contrib.gis.db.backends.postgis",
     )
 }
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,7 @@ xlrd==0.9.3
 django-moj-irat>=0.4
 # https://github.com/celery/kombu/issues/1063
 kombu==4.6.3
+dj-database-url==0.5.0
 
 # locks for Python 2.7
 more-itertools==5.0.0


### PR DESCRIPTION
## What does this pull request do?

Removes the multiple $DB_* environment variables and replaces them with one $DATABASE_URL connection string environment variable.

## Any other changes that would benefit highlighting?

The `psql` command doesn't seem to work with the `postgis://` connection string but works with `postgres://`. So I had to change `psql` command to `psql "${DATABASE_URL/postgis/postgres}"` in the `docker/setup_postgres.sh` script

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
- [x] Tested provider spreadsheet upload
