### PR TITLE
Add Docker security scanning with trivy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,41 @@ jobs:
             source env/bin/activate
             python manage.py test
 
+  image_security_scan:
+    docker:
+      - image: docker:18.09.3-git
+    steps:
+      - setup_remote_docker:
+          version: "18.09.3"
+      - run:
+          name: Login to the Docker registry
+          command: |
+            apk add --no-cache --no-progress py2-pip
+            pip install awscli
+            ecr_login="$(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)"
+            ${ecr_login}
+      - run:
+          name: Install trivy
+          command: |
+            apk add --update curl
+            VERSION=$(
+                curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | \
+                grep '"tag_name":' | \
+                sed -E 's/.*"v([^"]+)".*/\1/'
+            )
+
+            wget https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-64bit.tar.gz
+            tar zxvf trivy_${VERSION}_Linux-64bit.tar.gz
+            mv trivy /usr/local/bin
+      - run:
+          name: Pull down image
+          command: docker pull ${ECR_DOCKER_REPO_BASE}
+      - run:
+          name: Scan the image with trivy
+          command: |
+            trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM,HIGH --no-progress ${ECR_DOCKER_REPO_BASE}
+            trivy --exit-code 1 --severity CRITICAL --no-progress ${ECR_DOCKER_REPO_BASE}
+
   staging_deploy:
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
@@ -137,6 +172,9 @@ workflows:
           requires:
             - lint
             - test
+      - image_security_scan:
+          requires:
+            - build
       - staging_deploy_approval:
           type: approval
           requires:
@@ -148,6 +186,7 @@ workflows:
           type: approval
           requires:
             - staging_deploy
+            - image_security_scan
           filters:
             branches:
                 only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ jobs:
     steps:
       - setup_remote_docker:
           version: "18.09.3"
+      - checkout
       - run:
           name: Login to the Docker registry
           command: |
@@ -123,12 +124,15 @@ jobs:
             mv trivy /usr/local/bin
       - run:
           name: Pull down image
-          command: docker pull ${ECR_DOCKER_REPO_BASE}
+          command: |
+            source .circleci/define_build_environment_variables
+            docker pull ${ECR_DEPLOY_IMAGE}
       - run:
           name: Scan the image with trivy
           command: |
-            trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM,HIGH --no-progress ${ECR_DOCKER_REPO_BASE}
-            trivy --exit-code 1 --severity CRITICAL --no-progress ${ECR_DOCKER_REPO_BASE}
+            source .circleci/define_build_environment_variables
+            trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM,HIGH --no-progress ${ECR_DEPLOY_IMAGE}
+            trivy --exit-code 1 --severity CRITICAL --no-progress ${ECR_DEPLOY_IMAGE}
 
   staging_deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,10 +128,14 @@ jobs:
             source .circleci/define_build_environment_variables
             docker pull ${ECR_DEPLOY_IMAGE}
       - run:
-          name: Scan the image with trivy
+          name: Scan for vulnerabilities (informative, non-breaking)
           command: |
             source .circleci/define_build_environment_variables
             trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM,HIGH --no-progress ${ECR_DEPLOY_IMAGE}
+      - run:
+          name: Scan for breaking vulnerabilities
+          command: |
+            source .circleci/define_build_environment_variables
             trivy --exit-code 1 --severity CRITICAL --no-progress ${ECR_DEPLOY_IMAGE}
 
   staging_deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM osgeo/gdal:alpine-normal-v2.4.1
 
-RUN apk add --no-cache \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
       bash \
       postgresql-client \
       py2-pip \


### PR DESCRIPTION
## What does this pull request do?

I came across [trivy](https://github.com/aquasecurity/trivy) in ThoughtWorks' technology radar:
https://www.thoughtworks.com/radar/tools?blipid=201911077

> Our teams particularly like Trivy, a vulnerability scanner for
> containers, because it's easier to set up than other tools, thanks to
> it shipping as a stand-alone binary.

Stand-alone setup sounded like a good fit for our use-case, so I decided
to give it a try.

## Any other changes that would benefit highlighting?

Currently, only critical severity problems cause a pipeline failure and
_only_ production requires the scan to pass.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title" **Not applicable.**
