### PR TITLE
Revert "[Security] Bump django from 1.11.20 to 1.11.23"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ boto3==1.9.159
 celery[redis]==4.3.0
 django-celery-results==1.1.2
 django-filter==1.1
-django==1.11.23
+django==1.11.20
 django-storages==1.7.1
 djangorestframework-gis==0.14.0
 djangorestframework==3.9.3


### PR DESCRIPTION
Reverts ministryofjustice/laa-legal-adviser-api#138

Broker production with the following errors:
`[pid: 51| GET /admin/import-progress/ => generated 27 bytes in 207 msecs (HTTP/1.1 500) 5 headers in 173 bytes (1 switches on core 0)
  File "/usr/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python2.7/site-packages/django/views/decorators/cache.py", line 57, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/home/app/laalaa/apps/advisers/views.py", line 196, in import_progress
    "task": res.get("task"),
AttributeError: 'WorkerLostError' object has no attribute 'get'`