### PR TITLE
LGA-946 - Django 2.2 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
               .
       - run:
           name: Validate Python version
-          command: docker run --rm --tty --interactive application:$CIRCLE_SHA1 python --version | grep "2.7"
+          command: docker run --rm --tty --interactive application:$CIRCLE_SHA1 python --version | grep "3.7"
       - run:
           name: Tag and push Docker images
           command: .circleci/tag_and_push_docker_image application:$CIRCLE_SHA1 ${ECR_DOCKER_REPO_BASE}
@@ -65,7 +65,7 @@ jobs:
             black --check --skip-string-normalization laalaa
   test:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.7
       - image: circleci/postgres:9.4-alpine-postgis
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,12 @@ RUN apk add --no-cache \
 
 WORKDIR /home/app
 
+RUN rm /usr/bin/python && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    ln -s /usr/bin/pip3 /usr/bin/pip
+
 COPY requirements/base.txt requirements/base.txt
-RUN pip3 install -r ./requirements/base.txt
+RUN pip install -r ./requirements/base.txt
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk upgrade --no-cache && \
     apk add --no-cache \
       bash \
       postgresql-client \
-      py2-pip \
+      py3-pip \
       tzdata
 
 RUN adduser -D app && \
@@ -15,13 +15,13 @@ RUN apk add --no-cache \
       build-base \
       linux-headers \
       postgresql-dev \
-      python2-dev && \
-    pip install -U setuptools pip==18.1 wheel
+      python3-dev && \
+    pip3 install -U setuptools pip==18.1 wheel
 
 WORKDIR /home/app
 
 COPY requirements/base.txt requirements/base.txt
-RUN pip install -r ./requirements/base.txt
+RUN pip3 install -r ./requirements/base.txt
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN apk upgrade --no-cache && \
     apk add --no-cache \
       bash \
       postgresql-client \
-      py3-pip \
       tzdata
 
 RUN adduser -D app && \
@@ -14,15 +13,15 @@ RUN adduser -D app && \
 RUN apk add --no-cache \
       build-base \
       linux-headers \
-      postgresql-dev \
-      python3-dev && \
-    pip3 install -U setuptools pip==18.1 wheel
+      postgresql-dev
+
+# Install python3.7 from a later repository than the base image uses
+RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/v3.10/main python3-dev=3.7.5-r1 && \
+    rm /usr/bin/python && \
+        ln -s /usr/bin/python3 /usr/bin/python && \
+        ln -s /usr/bin/pip3 /usr/bin/pip
 
 WORKDIR /home/app
-
-RUN rm /usr/bin/python && \
-    ln -s /usr/bin/python3 /usr/bin/python && \
-    ln -s /usr/bin/pip3 /usr/bin/pip
 
 COPY requirements/base.txt requirements/base.txt
 RUN pip install -r ./requirements/base.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,9 @@ RUN apk add --no-cache \
 # Install python3.7 from a later repository than the base image uses
 RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/v3.10/main python3-dev=3.7.5-r1 && \
     rm /usr/bin/python && \
-        ln -s /usr/bin/python3 /usr/bin/python && \
-        ln -s /usr/bin/pip3 /usr/bin/pip
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    ln -s /usr/bin/pip3 /usr/bin/pip && \
+    pip install -U setuptools pip==18.1 wheel
 
 WORKDIR /home/app
 

--- a/laalaa/apps/advisers/middleware.py
+++ b/laalaa/apps/advisers/middleware.py
@@ -1,7 +1,8 @@
 from django.http import HttpResponse
+from django.utils.deprecation import MiddlewareMixin
 
 
-class PingMiddleware:
+class PingMiddleware(MiddlewareMixin):
     def process_request(self, request):
         if request.method == "GET":
             if request.path == "/ping.json":

--- a/laalaa/apps/advisers/middleware.py
+++ b/laalaa/apps/advisers/middleware.py
@@ -1,16 +1,17 @@
 from django.http import HttpResponse
-from django.utils.deprecation import MiddlewareMixin
 
 
-class PingMiddleware(MiddlewareMixin):
-    def process_request(self, request):
-        if request.method == "GET":
-            if request.path == "/ping.json":
-                return self.ping(request)
-        pass
+class PingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.ping(request) or self.get_response(request)
 
     def ping(self, request):
         """
         Returns that the server is alive.
         """
-        return HttpResponse("OK")
+        if request.method == "GET":
+            if request.path == "/ping.json":
+                return HttpResponse("OK")

--- a/laalaa/apps/advisers/migrations/0001_initial.py
+++ b/laalaa/apps/advisers/migrations/0001_initial.py
@@ -37,7 +37,7 @@ class Migration(migrations.Migration):
                 ("id", models.AutoField(verbose_name="ID", serialize=False, auto_created=True, primary_key=True)),
                 ("telephone", models.CharField(max_length=48)),
                 ("account_number", models.CharField(unique=True, max_length=10)),
-                ("location", models.ForeignKey(to="advisers.Location")),
+                ("location", models.ForeignKey(to="advisers.Location", on_delete=models.CASCADE)),
             ],
             options={},
             bases=(models.Model,),
@@ -66,8 +66,8 @@ class Migration(migrations.Migration):
             name="OutreachService",
             fields=[
                 ("id", models.AutoField(verbose_name="ID", serialize=False, auto_created=True, primary_key=True)),
-                ("location", models.ForeignKey(to="advisers.Location")),
-                ("office", models.ForeignKey(to="advisers.Office")),
+                ("location", models.ForeignKey(to="advisers.Location", on_delete=models.CASCADE)),
+                ("office", models.ForeignKey(to="advisers.Office", on_delete=models.CASCADE)),
             ],
             options={},
             bases=(models.Model,),
@@ -84,19 +84,19 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="outreachservice",
             name="type",
-            field=models.ForeignKey(to="advisers.OutreachType"),
+            field=models.ForeignKey(to="advisers.OutreachType", on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name="organisation",
             name="type",
-            field=models.ForeignKey(to="advisers.OrganisationType"),
+            field=models.ForeignKey(to="advisers.OrganisationType", on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name="office",
             name="organisation",
-            field=models.ForeignKey(to="advisers.Organisation"),
+            field=models.ForeignKey(to="advisers.Organisation", on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/laalaa/apps/advisers/migrations/0004_auto_20150407_1228.py
+++ b/laalaa/apps/advisers/migrations/0004_auto_20150407_1228.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="category",
             name="firm",
-            field=models.ForeignKey(to="advisers.Organisation", null=True),
+            field=models.ForeignKey(to="advisers.Organisation", null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AlterField(

--- a/laalaa/apps/advisers/migrations/0006_import.py
+++ b/laalaa/apps/advisers/migrations/0006_import.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("filename", models.TextField()),
-                ("user", models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True)),
+                ("user", models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE)),
             ],
             options={},
             bases=(models.Model,),

--- a/laalaa/apps/advisers/migrations/0007_auto_20151014_1428.py
+++ b/laalaa/apps/advisers/migrations/0007_auto_20151014_1428.py
@@ -41,13 +41,13 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="office",
             name="location",
-            field=models.OneToOneField(null=True, to="advisers.Location"),
+            field=models.OneToOneField(null=True, to="advisers.Location", on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AlterField(
             model_name="outreachservice",
             name="location",
-            field=models.OneToOneField(null=True, to="advisers.Location"),
+            field=models.OneToOneField(null=True, to="advisers.Location", on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.RunPython(load_fixture, reverse_code=unload_fixture),

--- a/laalaa/apps/advisers/models.py
+++ b/laalaa/apps/advisers/models.py
@@ -54,13 +54,13 @@ class Organisation(models.Model):
     name = models.CharField(max_length=255)
     website = models.URLField(null=True, blank=True)
     contracted = models.BooleanField(default=True)
-    type = models.ForeignKey("OrganisationType")
+    type = models.ForeignKey("OrganisationType", on_delete=models.CASCADE)
 
     def __unicode__(self):
         return unicode(self.name)
 
 
-class LocationManager(models.GeoManager):
+class LocationManager(models.Manager):
     def get_queryset(self):
         return (
             super(LocationManager, self)
@@ -118,8 +118,8 @@ class Location(models.Model):
 class Office(models.Model):
     telephone = models.CharField(max_length=48)
     account_number = models.CharField(max_length=10, unique=True)
-    organisation = models.ForeignKey("Organisation")
-    location = models.OneToOneField("Location", null=True)
+    organisation = models.ForeignKey("Organisation", on_delete=models.CASCADE)
+    location = models.OneToOneField("Location", null=True, on_delete=models.CASCADE)
     categories = models.ManyToManyField(Category)
 
 
@@ -131,9 +131,9 @@ class OutreachType(models.Model):
 
 
 class OutreachService(models.Model):
-    office = models.ForeignKey("Office")
-    location = models.OneToOneField("Location", null=True)
-    type = models.ForeignKey("OutreachType")
+    office = models.ForeignKey("Office", on_delete=models.CASCADE)
+    location = models.OneToOneField("Location", null=True, on_delete=models.CASCADE)
+    type = models.ForeignKey("OutreachType", on_delete=models.CASCADE)
     categories = models.ManyToManyField(Category)
 
     @property
@@ -164,4 +164,4 @@ class Import(models.Model):
     started = models.DateTimeField(auto_now_add=True)
     status = models.CharField(max_length=7, choices=list(IMPORT_STATUSES))
     filename = models.TextField()
-    user = models.ForeignKey(User, null=True)
+    user = models.ForeignKey(User, null=True, on_delete=models.CASCADE)

--- a/laalaa/apps/advisers/tasks.py
+++ b/laalaa/apps/advisers/tasks.py
@@ -72,7 +72,7 @@ class StrippedDict(dict):
 
 
 class GeocoderTask(Task):
-    name = 'advisers.tasks.GeocoderTask'
+    name = "advisers.tasks.GeocoderTask"
 
     def __init__(self):
         self.errors = []
@@ -85,7 +85,7 @@ class GeocoderTask(Task):
             self.errors.append(err)
 
         for n, postcode in enumerate(postcodes):
-            pc = re.sub(" +", " ", postcode[0]).encode("utf-8")
+            pc = re.sub(" +", " ", postcode[0])
             try:
                 point = geocode(pc)
             except geocoder.PostcodeNotFound:
@@ -102,7 +102,7 @@ class GeocoderTask(Task):
 
 
 class ProgressiveAdviserImport(Task):
-    name = 'advisers.tasks.ProgressiveAdviserImport'
+    name = "advisers.tasks.ProgressiveAdviserImport"
 
     worksheet_names = (
         "LOCAL ADVICE ORG",
@@ -208,12 +208,13 @@ class ProgressiveAdviserImport(Task):
         def value(cell):
             if cell.ctype == xlrd.XL_CELL_NUMBER:
                 return int(cell.value)
-            return cell.value.encode("utf-8", errors="ignore")
+            return cell.value
 
-        with open(csv_filename, "wb") as csv_file:
+        with open(csv_filename, "w") as csv_file:
             writer = csv.writer(csv_file, quoting=csv.QUOTE_ALL)
             for row in xrange(worksheet.nrows):
-                writer.writerow([value(cell) for cell in worksheet.row(row)])
+                items = [value(cell) for cell in worksheet.row(row)]
+                writer.writerow(items)
         return csv_filename, headers, types
 
     def load_csv_into_db(self, csv_filename, headers, types):

--- a/laalaa/apps/advisers/tests/test_geocoder.py
+++ b/laalaa/apps/advisers/tests/test_geocoder.py
@@ -108,7 +108,7 @@ class AdviserViewSetTest(django.test.TestCase):
         )
 
         office = models.Office.objects.create(telephone="0200 000 0000", location=loc, organisation=org)
-        office.categories = [category]
+        office.categories.set([category])
         office.save()
 
     @mock.patch("advisers.geocoder.lookup_postcode")

--- a/laalaa/apps/advisers/urls.py
+++ b/laalaa/apps/advisers/urls.py
@@ -7,7 +7,7 @@ from categories.views import CategoryViewSet
 
 
 router = routers.DefaultRouter()
-router.register(r"legal-advisers", views.AdviserViewSet, base_name="legal-advisers")
-router.register(r"categories_of_law", CategoryViewSet, base_name="categories")
+router.register(r"legal-advisers", views.AdviserViewSet, basename="legal-advisers")
+router.register(r"categories_of_law", CategoryViewSet, basename="categories")
 
 urlpatterns = [url(r"^", include(router.urls))]

--- a/laalaa/apps/advisers/views.py
+++ b/laalaa/apps/advisers/views.py
@@ -134,7 +134,11 @@ class AdviserViewSet(viewsets.ReadOnlyModelViewSet):
         else:
             origin = self.get_origin_point() or self.get_origin_postcode()
             if origin:
-                return queryset.distance(origin, field_name="point").order_by("distance")
+                # srid is required for calculating when distance otherwise Distance will throw an exception
+                origin.srid = origin.srid or 4326
+                from django.contrib.gis.db.models.functions import Distance
+
+                return queryset.annotate(distance=Distance("point", origin)).order_by("distance")
 
         return queryset
 

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -62,14 +62,13 @@ INSTALLED_APPS = (
     "categories",
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     "advisers.middleware.PingMiddleware",
     "django.middleware.cache.UpdateCacheMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.auth.middleware.SessionAuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.cache.FetchFromCacheMiddleware",
@@ -196,9 +195,7 @@ if "SENTRY_DSN" in os.environ:
 
     INSTALLED_APPS += ("raven.contrib.django.raven_compat",)
 
-    MIDDLEWARE_CLASSES = (
-        "raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware",
-    ) + MIDDLEWARE_CLASSES
+    MIDDLEWARE = ("raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware",) + MIDDLEWARE
 
 
 # .local.py overrides all the common settings.

--- a/laalaa/urls.py
+++ b/laalaa/urls.py
@@ -8,6 +8,6 @@ from moj_irat.views import HealthcheckView
 
 urlpatterns = [
     url(r"^healthcheck.json$", never_cache(HealthcheckView.as_view()), name="healthcheck_json"),
-    url(r"^admin/", include(admin_site.urls)),
+    url(r"^admin/", admin_site.urls),
     url(r"^", include("advisers.urls")),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,3 @@ xlrd~=1.0
 django-moj-irat>=0.4
 
 dj-database-url==0.5.0
-
-# locks for Python 2.7
-more-itertools==5.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,5 +13,4 @@ requests==2.20.0
 uwsgi==2.0.17.1
 xlrd~=1.0
 django-moj-irat>=0.4
-
 dj-database-url==0.5.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 boto3==1.9.159
-celery[redis]==4.3.0
+celery[redis]==4.4.0
 django-celery-results==1.1.2
 django-filter==1.1
 django~=2.2
@@ -13,8 +13,7 @@ requests==2.20.0
 uwsgi==2.0.17.1
 xlrd~=1.0
 django-moj-irat>=0.4
-# https://github.com/celery/kombu/issues/1063
-kombu==4.6.3
+
 dj-database-url==0.5.0
 
 # locks for Python 2.7

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,16 +2,16 @@ boto3==1.9.159
 celery[redis]==4.3.0
 django-celery-results==1.1.2
 django-filter==1.1
-django==1.11.23
+django~=2.2
 django-storages==1.7.1
 djangorestframework-gis==0.14.0
 djangorestframework==3.9.3
 logstash-formatter==0.5.9
 psycopg2-binary==2.7.5
-raven==5.2.0
+raven~=6.0
 requests==2.20.0
 uwsgi==2.0.17.1
-xlrd==0.9.3
+xlrd~=1.0
 django-moj-irat>=0.4
 # https://github.com/celery/kombu/issues/1063
 kombu==4.6.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ boto3==1.9.159
 celery[redis]==4.4.0
 django-celery-results==1.1.2
 django-filter==1.1
-django~=2.2
+django==2.2.10
 django-storages==1.7.1
 djangorestframework-gis==0.14.0
 djangorestframework==3.9.3
@@ -11,6 +11,6 @@ psycopg2-binary==2.7.5
 raven~=6.0
 requests==2.20.0
 uwsgi==2.0.17.1
-xlrd~=1.0
+xlrd==1.2.0
 django-moj-irat>=0.4
 dj-database-url==0.5.0


### PR DESCRIPTION
## What does this pull request do?

### Upgrade from Django 1.x to 2.2
- Change MIDDLEWARE_CLASSES to MIDDLEWARE in the settings
- Upgraded advisers.middleware.PingMiddleware to work with django 2.2 middleware spec
- Added on_delete=models.CASCADE to all ForeignKey and OneToOne model fields. Including existing migrations
- Removed SessionAuthenticationMiddleware middleware from settings. It provided no functionality since session authentication is unconditionally enabled in Django 1.10
- Removed GeoManager as parent of LocationManager as all methods have been deprecated and replaced by equivalent database functions.  

### Upgrade from Python2.7 to Python3.7 (Django 2.2 does not support python2.7)

## Any other changes that would benefit highlighting?

Had to use http://dl-cdn.alpinelinux.org/alpine/v3.10/main python3-dev=3.7.5-r1 repository to install python 3.7 instead of latest version in the edge repository which at the time of this PR is 3.8. This also installs pip3 so we didn't need install that separately. 

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
