### PR TITLE
LGA-696 - Code coverage on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,17 @@ jobs:
           name: Run unit tests
           command: |
             source env/bin/activate
-            python manage.py test
+            coverage run manage.py test --verbosity=2
+            coverage report -m
+            coverage html
+            coveralls
+      - store_artifacts:
+          path: htmlcov
+          destination: coverage
+      - store_test_results:
+          path: test-reports
+      - store_artifacts:
+          path: test-reports
 
   image_security_scan:
     docker:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+source = laalaa
+omit =
+        *migrations*
+        settings/*

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ node_modules/
 
 laalaa/settings/local.py
 laalaa/static/
+test-reports/

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ node_modules/
 laalaa/settings/local.py
 laalaa/static/
 test-reports/
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LAA Legal Adviser API
 
+[![Coverage Status](https://coveralls.io/repos/github/ministryofjustice/laa-legal-adviser-api/badge.svg?branch=master)](https://coveralls.io/github/ministryofjustice/laa-legal-adviser-api?branch=master)
+
 Service to search for nearby LAA Legal Advisers by postcode.
 
 The search is based on looking up latitude and longitude from the given postcode and finding legal advisers who are

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -197,6 +197,8 @@ if "SENTRY_DSN" in os.environ:
 
     MIDDLEWARE = ("raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware",) + MIDDLEWARE
 
+TEST_RUNNER = "xmlrunner.extra.djangotestrunner.XMLTestRunner"
+TEST_OUTPUT_DIR = "test-reports"
 
 # .local.py overrides all the common settings.
 try:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,3 +5,4 @@ mock
 responses==0.9.0
 pre-commit==1.14.2
 unittest-xml-reporting==3.0.1
+coverage==5.0.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,3 +6,4 @@ responses==0.9.0
 pre-commit==1.14.2
 unittest-xml-reporting==3.0.1
 coverage==5.0.3
+coveralls==1.11.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,3 +4,4 @@ werkzeug
 mock
 responses==0.9.0
 pre-commit==1.14.2
+unittest-xml-reporting==3.0.1


### PR DESCRIPTION
## What does this pull request do?

Wraps test running in coverage
Stores the output on circleci as artifacts
Sends coverage results to coveralls.io
Adds a coveralls badge to the readme
Generates and stores test metadata in xml format for CircleCI to monitor

## Any other changes that would benefit highlighting?

Based on https://github.com/ministryofjustice/cla_backend/pull/583

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
