### PR TITLE
LGA-1281 - Upgrade kubernetes apis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache \
       postgresql-dev
 
 # Install python3.7 from a later repository than the base image uses
-RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/v3.10/main python3-dev=3.7.5-r1 && \
+RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/v3.10/main python3-dev=3.7.7-r0 && \
     rm /usr/bin/python && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     ln -s /usr/bin/pip3 /usr/bin/pip && \

--- a/kubernetes_deploy/development/deployment.yml
+++ b/kubernetes_deploy/development/deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:

--- a/kubernetes_deploy/development/queue_worker_deployment.yml
+++ b/kubernetes_deploy/development/queue_worker_deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:

--- a/kubernetes_deploy/development/shared_services_deployment.yml
+++ b/kubernetes_deploy/development/shared_services_deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:

--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: laa-legal-adviser-api

--- a/kubernetes_deploy/production/queue_worker_deployment.yml
+++ b/kubernetes_deploy/production/queue_worker_deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:

--- a/kubernetes_deploy/staging/ingress.yml
+++ b/kubernetes_deploy/staging/ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: laa-legal-adviser-api

--- a/kubernetes_deploy/staging/queue_worker_deployment.yml
+++ b/kubernetes_deploy/staging/queue_worker_deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,6 @@ werkzeug
 mock
 responses==0.9.0
 pre-commit==1.14.2
-unittest-xml-reporting==3.0.1
+unittest-xml-reporting==3.0.2
 coverage==5.0.3
 coveralls==1.11.0


### PR DESCRIPTION
## What does this pull request do?
Switches some kubernetes resources from old versions to their newer ones (in different resource groups).
These changes are backwards compatible, and the server will use any versions it supports interchangeably.

## Any other changes that would benefit highlighting?
Updates Python version and one package requirement to allow the image to still build.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
