### PR TITLE
WIP - LGA-1464 - uwsgi graceful termination workaround

### DIFF
--- a/conf/uwsgi.ini
+++ b/conf/uwsgi.ini
@@ -10,3 +10,4 @@ enable-threads=True
 processes=2
 harakiri=30
 post-buffering=1
+die-on-term=True

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -20,6 +20,7 @@ spec:
         service_area: laa-get-access
         service_team: cla-fala
     spec:
+      terminationGracePeriodSeconds: 30
       containers:
       - image: "<to be set by deploy_to_kubernetes>"
         name: app
@@ -37,6 +38,10 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 1
           periodSeconds: 10
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sleep","10"]
         env:
         - name: ENV
           value: prod


### PR DESCRIPTION
## What does this pull request do?

Add preStop lifecycle hook and terminationGracePeriod to allow enough time for uwsgi finish processing requests

Changes explained:

- **die-on-term** - respect the convention of shutting down the instance
- **preStop** - Sleep for 30 seconds. Called before receiving SIGTERM. Aim here is to sleep enough time for the current requests to finish.
- **terminationGracePeriodSeconds** - Amount of time kubernetes waits before sending us the SIGKILL signal.

Important note from the [kubernetes documentation ](https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-terminating-with-grace)on how the preStop and terminationGracePeriodSeconds interact:

> It’s important to note that this(_terminationGracePeriodSeconds_) happens in parallel to the preStop hook and the SIGTERM signal. Kubernetes does not wait for the preStop hook to finish.
If your app finishes shutting down and exits before the terminationGracePeriod is done, Kubernetes moves to the next step immediately.

## Any other changes that would benefit highlighting?

Related PR https://github.com/ministryofjustice/cla_backend/pull/665
Set sleep time to 10 seconds as opposed to 30 in the related PR -- because these requests should be lighter than the cla_backend project

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
