### PR TITLE
LGA-1507 - Sentry SDK

### DIFF
--- a/kubernetes_deploy/production/queue_worker_deployment.yml
+++ b/kubernetes_deploy/production/queue_worker_deployment.yml
@@ -37,6 +37,8 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 10
         env:
+        - name: ENV
+          value: prod
         - name: WORKER_APP_CONCURRENCY
           value: "8"
         - name: LOG_LEVEL

--- a/kubernetes_deploy/staging/collect-static-job.yml
+++ b/kubernetes_deploy/staging/collect-static-job.yml
@@ -20,6 +20,8 @@ spec:
         image: "<to be set by deploy_to_kubernetes>"
         command: ["python", "manage.py", "collectstatic", "--noinput"]
         env:
+        - name: ENV
+          value: staging
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -38,6 +38,8 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 10
         env:
+        - name: ENV
+          value: staging
         - name: LOG_LEVEL
           value: INFO
         - name: SECRET_KEY

--- a/kubernetes_deploy/staging/migrate-db-job.yml
+++ b/kubernetes_deploy/staging/migrate-db-job.yml
@@ -20,6 +20,8 @@ spec:
         image: "<to be set by deploy_to_kubernetes>"
         command: ["python", "manage.py", "migrate", "--noinput"]
         env:
+        - name: ENV
+          value: staging
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/kubernetes_deploy/staging/queue_worker_deployment.yml
+++ b/kubernetes_deploy/staging/queue_worker_deployment.yml
@@ -37,6 +37,8 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 10
         env:
+        - name: ENV
+          value: staging
         - name: WORKER_APP_CONCURRENCY
           value: "8"
         - name: LOG_LEVEL

--- a/laalaa/celery.py
+++ b/laalaa/celery.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import
 
 import os
 
-from raven.contrib.celery import register_logger_signal
-from raven.scripts.runner import send_test_message
 from celery import Celery
 
 # set the default Django settings module for the 'celery' program.
@@ -19,20 +17,7 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
-client = None
-if hasattr(settings, "RAVEN_CONFIG"):
-    from raven.contrib.django.models import client
-
-    register_logger_signal(client)
-    register_logger_signal(client)
-
 
 @app.task(bind=True)
 def debug_task(self):
     print("Request: {0!r}".format(self.request))
-
-
-@app.task()
-def sentry_test_task():
-    if client:
-        send_test_message(client, {})

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -198,7 +198,7 @@ if "SENTRY_DSN" in os.environ:
         dsn=os.environ.get("SENTRY_DSN"),
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        environment=os.environ.get("ENV", "unknown")
+        environment=os.environ.get("ENV", "unknown"),
     )
 
 TEST_RUNNER = "xmlrunner.extra.djangotestrunner.XMLTestRunner"

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -13,7 +13,10 @@ import os
 from os.path import join, abspath, dirname
 import sys
 import ssl
+
 import dj_database_url
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
 
 
 def here(*x):
@@ -189,13 +192,14 @@ LOGGING["handlers"]["console"] = {"level": "DEBUG", "class": "logging.StreamHand
 
 LOGGING["loggers"][""] = {"handlers": ["console"], "level": "DEBUG"}
 
-# RAVEN SENTRY CONFIG
+# SENTRY CONFIG
 if "SENTRY_DSN" in os.environ:
-    RAVEN_CONFIG = {"dsn": os.environ.get("SENTRY_DSN")}
-
-    INSTALLED_APPS += ("raven.contrib.django.raven_compat",)
-
-    MIDDLEWARE = ("raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware",) + MIDDLEWARE
+    sentry_sdk.init(
+        dsn=os.environ.get("SENTRY_DSN"),
+        integrations=[DjangoIntegration()],
+        traces_sample_rate=1.0,
+        environment=os.environ.get("ENV", "unknown")
+    )
 
 TEST_RUNNER = "xmlrunner.extra.djangotestrunner.XMLTestRunner"
 TEST_OUTPUT_DIR = "test-reports"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
+requests==2.20.0
 boto3==1.9.159
 celery[redis]==4.4.0
 django-celery-results==1.1.2
@@ -9,7 +10,6 @@ djangorestframework==3.9.3
 logstash-formatter==0.5.9
 psycopg2-binary==2.8.6
 sentry-sdk==0.19.2
-requests==2.20.0
 uwsgi==2.0.17.1
 xlrd==1.2.0
 django-moj-irat>=0.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ djangorestframework-gis==0.14.0
 djangorestframework==3.9.3
 logstash-formatter==0.5.9
 psycopg2-binary==2.7.5
-raven~=6.0
+sentry-sdk==0.19.2
 requests==2.20.0
 uwsgi==2.0.17.1
 xlrd==1.2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ django-storages==1.7.1
 djangorestframework-gis==0.14.0
 djangorestframework==3.9.3
 logstash-formatter==0.5.9
-psycopg2-binary==2.7.5
+psycopg2-binary==2.8.6
 sentry-sdk==0.19.2
 requests==2.20.0
 uwsgi==2.0.17.1


### PR DESCRIPTION
## What does this pull request do?
Replaces the Raven library with the more modern Sentry SDK

## Any other changes that would benefit highlighting?
This repo is a nice simple one, doesn't seem to have presented anything we didn't already deal with for `cla_backend`
Sets the ENV env var more consistently, as it's now used for more than just ensuring an environment is not production for a particular job.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
