### PR TITLE
LGA-1634 - Upgrade python package to python3.8.7-r2 to fix [CVE-2021-3177]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
               .
       - run:
           name: Validate Python version
-          command: docker run --rm --tty --interactive application:$CIRCLE_SHA1 python --version | grep "3.7"
+          command: docker run --rm --tty --interactive application:$CIRCLE_SHA1 python --version | grep "3.8"
       - run:
           name: Tag and push Docker images
           command: .circleci/tag_and_push_docker_image application:$CIRCLE_SHA1 ${ECR_DOCKER_REPO_BASE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache \
       linux-headers \
       postgresql-dev
 
-# Remove the python3 version included by the base image install the latest version that fixes [CVE-2021-3177]
+# Remove the python3 version included by the base image; install the latest version that fixes [CVE-2021-3177]
 RUN apk del python3 \
     && apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main python3-dev \
     && apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community py3-pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osgeo/gdal:alpine-normal-v2.4.1
+FROM osgeo/gdal:alpine-normal-3.2.1
 
 RUN apk upgrade --no-cache && \
     apk add --no-cache \
@@ -15,12 +15,11 @@ RUN apk add --no-cache \
       linux-headers \
       postgresql-dev
 
-# Install python3.7 from a later repository than the base image uses
-RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/v3.10/main python3-dev=3.7.7-r1 && \
-    rm /usr/bin/python && \
-    ln -s /usr/bin/python3 /usr/bin/python && \
-    ln -s /usr/bin/pip3 /usr/bin/pip && \
-    pip install -U setuptools pip==18.1 wheel
+# Remove the python3 version included by the base image install the latest version that fixes [CVE-2021-3177]
+RUN apk del python3 \
+    && apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main python3-dev \
+    && apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community py3-pip \
+    && pip install -U setuptools pip==18.1 wheel
 
 WORKDIR /home/app
 


### PR DESCRIPTION
## What does this pull request do?

Upgrade python package to python3.8.7-r2 to fix [CVE-2021-3177]

## Any other changes that would benefit highlighting?
Bug as reported https://bugs.python.org/issue42938
The bug was fixed in the [python3.8.7-r2 package](https://pkgs.alpinelinux.org/package/edge/main/x86_64/python3) by this comment https://git.alpinelinux.org/aports/commit/?id=5e7e1c23fb66dbdbd37939157ceb2ea94535de1a

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
