### PR TITLE
LGA-1521 Fix database seeding issues

### DIFF
--- a/laalaa/apps/advisers/management/commands/seed.py
+++ b/laalaa/apps/advisers/management/commands/seed.py
@@ -8,24 +8,24 @@ from advisers import models
 class Command(BaseCommand):
     help = "Seeds the initial set of data for adviser locations, offices, etc."
     fixture_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../fixtures"))
+    fixture_filename = "initial_advisers.json"
 
     def handle(self, *args, **options):
         if models.Location.objects.count() > 0:
             print("Database already contains adviser data. Skipping seeding initial data.")
             return
 
-        for fixture_filename in os.listdir(self.fixture_dir):
-            fixture_file = os.path.join(self.fixture_dir, fixture_filename)
-            fixture = open(fixture_file, "rb")
-            objects = list(serializers.deserialize("json", fixture, ignorenonexistent=True))
+        fixture_file = os.path.join(self.fixture_dir, self.fixture_filename)
+        fixture = open(fixture_file, "rb")
+        objects = list(serializers.deserialize("json", fixture, ignorenonexistent=True))
 
-            print("Importing {} objects from {}".format(len(objects), fixture_file))
-            progress = 0
-            for obj in objects:
-                obj.save()
-                progress = progress + 1
-                if progress % 1000 == 0:
-                    print("{}...".format(progress))
+        print("Importing {} objects from {}".format(len(objects), fixture_file))
+        progress = 0
+        for obj in objects:
+            obj.save()
+            progress = progress + 1
+            if progress % 1000 == 0:
+                print("{}...".format(progress))
 
-            fixture.close()
-            print("Done!")
+        fixture.close()
+        print("Done!")

--- a/laalaa/apps/advisers/management/commands/seed.py
+++ b/laalaa/apps/advisers/management/commands/seed.py
@@ -8,24 +8,24 @@ from advisers import models
 class Command(BaseCommand):
     help = "Seeds the initial set of data for adviser locations, offices, etc."
     fixture_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../fixtures"))
-    fixture_filename = "initial_advisers.json"
 
     def handle(self, *args, **options):
         if models.Location.objects.count() > 0:
             print("Database already contains adviser data. Skipping seeding initial data.")
             return
 
-        fixture_file = os.path.join(self.fixture_dir, self.fixture_filename)
-        fixture = open(fixture_file, "rb")
-        objects = list(serializers.deserialize("json", fixture, ignorenonexistent=True))
+        for fixture_filename in os.listdir(self.fixture_dir):
+            fixture_file = os.path.join(self.fixture_dir, fixture_filename)
+            fixture = open(fixture_file, "rb")
+            objects = list(serializers.deserialize("json", fixture, ignorenonexistent=True))
 
-        print("Importing {} objects from {}".format(len(objects), fixture_file))
-        progress = 0
-        for obj in objects:
-            obj.save()
-            progress = progress + 1
-            if progress % 1000 == 0:
-                print("{}...".format(progress))
+            print("Importing {} objects from {}".format(len(objects), fixture_file))
+            progress = 0
+            for obj in objects:
+                obj.save()
+                progress = progress + 1
+                if progress % 1000 == 0:
+                    print("{}...".format(progress))
 
-        fixture.close()
-        print("Done!")
+            fixture.close()
+            print("Done!")

--- a/laalaa/apps/advisers/tests/test_seed.py
+++ b/laalaa/apps/advisers/tests/test_seed.py
@@ -3,8 +3,8 @@ from django.test import TestCase
 
 from advisers import models, tasks
 
-class SeedTest(TestCase):
 
+class SeedTest(TestCase):
     def test_seed_loads_models_with_organisation_type(self):
         tasks.clear_db()
         call_command("seed")

--- a/laalaa/apps/advisers/tests/test_seed.py
+++ b/laalaa/apps/advisers/tests/test_seed.py
@@ -1,0 +1,14 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+from advisers import models, tasks
+
+class SeedTest(TestCase):
+
+    def test_seed_loads_models_with_organisation_type(self):
+        tasks.clear_db()
+        call_command("seed")
+        # OrganisationType model loaded from initial_categories.json
+        self.assertGreater(models.OrganisationType.objects.count(), 0)
+        # Location model loaded from initial_advisers.json
+        self.assertGreater(models.Location.objects.count(), 0)


### PR DESCRIPTION
## What does this pull request do?

- Add all fixtures in `apps/advisers/fixtures` directory during seeding
- Fixtures directory includes `initial_advisers.json` and `initial_categories.json`
- Add test to ensure data from both fixtures are loaded

## Any other changes that would benefit highlighting?

Requires writing some tests 

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
