### PR TITLE
LGA-1802 - Remove the current task as well as those that are queued

### DIFF
--- a/laalaa/apps/advisers/management/commands/abort_last_import.py
+++ b/laalaa/apps/advisers/management/commands/abort_last_import.py
@@ -6,8 +6,10 @@ class Command(BaseCommand):
     help = "Abort last Import job"
 
     def handle(self, *args, **options):
-        Import.objects.abort_last()
-        self.get_celery_app().control.purge()
+        last = Import.objects.abort_last()
+        app = self.get_celery_app()
+        app.control.revoke(last.task_id, terminate=True)
+        app.control.purge()
 
     def get_celery_app(self):
         from celery import Celery

--- a/laalaa/apps/advisers/management/commands/abort_last_import.py
+++ b/laalaa/apps/advisers/management/commands/abort_last_import.py
@@ -1,19 +1,18 @@
 from django.core.management.base import BaseCommand
 from advisers.models import Import
+from .utils import AbortImportMixin
 
 
-class Command(BaseCommand):
+class Command(BaseCommand, AbortImportMixin):
     help = "Abort last Import job"
 
     def handle(self, *args, **options):
-        last = Import.objects.abort_last()
-        app = self.get_celery_app()
-        app.control.revoke(last.task_id, terminate=True)
-        app.control.purge()
-
-    def get_celery_app(self):
-        from celery import Celery
-
-        app = Celery("laalaa")
-        app.config_from_object("django.conf:settings", namespace="CELERY")
-        return app
+        last = Import.objects.last()
+        if last:
+            if last.is_in_progress():
+                self.stdout.write("Aborting import {}".format(last.pk))
+                self.abort_import(last)
+            else:
+                self.stderr.write("Not aborting import {} with status {}".format(last.pk, last.status))
+        else:
+            self.stderr.write("Could not find any import to attempt to abort")

--- a/laalaa/apps/advisers/management/commands/utils.py
+++ b/laalaa/apps/advisers/management/commands/utils.py
@@ -1,0 +1,26 @@
+class AbortImportMixin(object):
+    def abort_import(self, obj):
+        obj.abort()
+        self.cleanup_celery(obj)
+
+    def cleanup_celery(self, obj):
+        app = self.get_celery_app()
+        app.control.revoke(obj.task_id, terminate=True)
+        app.control.purge()
+        stats = app.control.inspect()
+        self.cancel_geocoding_tasks(app, stats.reserved())
+        self.cancel_geocoding_tasks(app, stats.active())
+
+    def cancel_geocoding_tasks(self, app, tasks):
+        for worker in tasks:
+            for task in tasks[worker]:
+                if task["name"] == "advisers.tasks.GeocoderTask":
+                    print("Cancelling task {} of {}".format(task["id"], task["name"]))
+                    app.control.revoke(task["id"], terminate=True)
+
+    def get_celery_app(self):
+        from celery import Celery
+
+        app = Celery("laalaa")
+        app.config_from_object("django.conf:settings", namespace="CELERY")
+        return app

--- a/laalaa/apps/advisers/management/commands/utils.py
+++ b/laalaa/apps/advisers/management/commands/utils.py
@@ -5,7 +5,7 @@ class AbortImportMixin(object):
 
     def cleanup_celery(self, obj):
         app = self.get_celery_app()
-        app.control.revoke(obj.task_id, terminate=True)
+        app.control.revoke(obj.task_id, terminate=True, signal="SIGUSR1")
         app.control.purge()
         stats = app.control.inspect()
         self.cancel_geocoding_tasks(app, stats.reserved())
@@ -14,9 +14,8 @@ class AbortImportMixin(object):
     def cancel_geocoding_tasks(self, app, tasks):
         for worker in tasks:
             for task in tasks[worker]:
-                if task["name"] == "advisers.tasks.GeocoderTask":
-                    print("Cancelling task {} of {}".format(task["id"], task["name"]))
-                    app.control.revoke(task["id"], terminate=True)
+                print("Cancelling task {} of {}".format(task["id"], task["name"]))
+                app.control.revoke(task["id"], terminate=True, signal="SIGUSR1")
 
     def get_celery_app(self):
         from celery import Celery

--- a/laalaa/apps/advisers/tests/test_commands.py
+++ b/laalaa/apps/advisers/tests/test_commands.py
@@ -26,7 +26,9 @@ class WorkerHealthCheckCommandTestCase(TestCase):
         app.control.purge = Mock()
         return app
 
-    def test_check_import_stuck_in_progress__created(self):
+    @patch("advisers.management.commands.worker_health_checks.Command.cleanup_celery")
+    def test_check_import_stuck_in_progress__created(self, mock_abort_import):
+        mock_abort_import.side_effect = Mock(return_value=True)
         Import.objects.create(task_id=1, status=IMPORT_STATUSES.CREATED, filename="filename", user=self.user)
         self.command.check_import_stuck_in_progress()
         self.command.import_created_status_stuck_interval = datetime.timedelta(minutes=-20)
@@ -34,7 +36,9 @@ class WorkerHealthCheckCommandTestCase(TestCase):
             self.command.check_import_stuck_in_progress()
         self.assertEqual(Import.objects.last().status, IMPORT_STATUSES.ABORTED)
 
-    def test_check_import_stuck_in_progress__running(self):
+    @patch("advisers.management.commands.worker_health_checks.Command.cleanup_celery")
+    def test_check_import_stuck_in_progress__running(self, mock_abort_import):
+        mock_abort_import.side_effect = Mock(return_value=True)
         Import.objects.create(task_id=1, status=IMPORT_STATUSES.CREATED, filename="filename", user=self.user)
         last_import = Import.objects.last()
         last_import.start()


### PR DESCRIPTION
## What does this pull request do?

`app.control.purge()` was only removing tasks in the queue, we  needed to instead call `app.control.revoke()` to remove tasks that running/scheduled(scheduled tasks, are tasks that the worker has claimed but has not yet started working on them)

## Any other changes that would benefit highlighting?
app.control.revoke(terminate=True) without an additional `signal="SIGUSR1"` parameter will cause the worker to be terminated and would raise a `billiard.exceptions.Terminated` exception that cannot be captured. See https://github.com/celery/celery/issues/2727 for more details

The `GeocoderTask` and `ProgressiveAdviserImport` celery tasks run handlers had to be wrapped in a try block to capture the `billiard.exceptions.SoftTimeLimitExceeded` exception that is raised when the tasks are revoked. The `except` block raises a `celery.exceptions.Ignore` exception to signal to celery not to call the on_success/on_failure handlers.


## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
