### PR TITLE
LGA-1896 - Add external DNS annotations to LAALAA ingress

### DIFF
--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -3,6 +3,9 @@ kind: Ingress
 metadata:
   name: laa-legal-adviser-api
   namespace: laa-legal-adviser-api-production
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: laa-legal-adviser-api-laa-legal-adviser-api-production-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:

--- a/kubernetes_deploy/staging/ingress.yml
+++ b/kubernetes_deploy/staging/ingress.yml
@@ -3,6 +3,9 @@ kind: Ingress
 metadata:
   name: laa-legal-adviser-api
   namespace: laa-legal-adviser-api-staging
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: laa-legal-adviser-api-laa-legal-adviser-api-staging-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
## What does this pull request do?

Add external DNS annotations to LAALAA ingress.

## Any other changes that would benefit highlighting?

Cloud Platforms is migrating from a self-hosted Kubernetes cluster to EKS.
As part of this migration, the load balancer will need to stop directing traffic to the existing instance of our service and start directing it to an instance of our service running on the new cluster. This cutover will be controlled by us, by annotations on our Ingress objects.

In preparation for this, we need to add annotations now that specify to direct all traffic to the current instance, so that when the load balancer starts reading these annotations it knows to continue as it is now until those annotations change

The `blue` suffix means to use the ingress in “live-1”

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/migrate-to-live.html#step-2-amend-and-apply-your-quot-live-1-quot-ingress-resource


## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
