### PR TITLE
LGA-1901 - Reduce Sentry performance data sampling rate

### DIFF
--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -193,11 +193,25 @@ LOGGING["handlers"]["console"] = {"level": "DEBUG", "class": "logging.StreamHand
 LOGGING["loggers"][""] = {"handlers": ["console"], "level": "DEBUG"}
 
 # SENTRY CONFIG
+LOW_SAMPLE_RATE_TRANSACTIONS = ["/ping.json", "/healthcheck.json"]
+
+
+def traces_sampler(sampling_context):
+    try:
+        name = sampling_context["wsgi_environ"].get("PATH_INFO")
+    except Exception:
+        pass
+    else:
+        if name in LOW_SAMPLE_RATE_TRANSACTIONS:
+            return 0.0001
+    return 0.1
+
+
 if "SENTRY_DSN" in os.environ:
     sentry_sdk.init(
         dsn=os.environ.get("SENTRY_DSN"),
         integrations=[DjangoIntegration()],
-        traces_sample_rate=1.0,
+        traces_sampler=traces_sampler,
         environment=os.environ.get("ENV", "unknown"),
     )
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ djangorestframework-gis==0.14.0
 djangorestframework==3.9.3
 logstash-formatter==0.5.9
 psycopg2-binary==2.8.6
-sentry-sdk==0.19.2
+sentry-sdk==0.19.3
 uwsgi==2.0.17.1
 xlrd==1.2.0
 django-moj-irat>=0.4


### PR DESCRIPTION
## What does this pull request do?

Reduce it to 0.1, and even further for our busiest, least-interesting routes

## Any other changes that would benefit highlighting?

Similar to ministryofjustice/cla_backend#734 

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
