### PR TITLE
LGA-1915 - Remove setup-kube-auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,30 +157,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Initialise Kubernetes staging context
+          name: Initialise Kubernetes << parameters.namespace >> context
           command: |
             setup-kube-auth
-            kubectl config use-context staging
+            kubectl config use-context << parameters.namespace >>
       - deploy:
           name: Deploy to << parameters.namespace >>
           command: |
             .circleci/deploy_to_kubernetes << parameters.namespace >>
-      - slack/status
-
-  production_deploy:
-    docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
-    steps:
-      - checkout
-      - run:
-          name: Initialise Kubernetes production context
-          command: |
-            setup-kube-auth
-            kubectl config use-context production
-      - deploy:
-          name: Deploy laalaa to production
-          command: |
-            .circleci/deploy_to_kubernetes production
       - slack/status
 
 workflows:
@@ -214,6 +198,8 @@ workflows:
             branches:
                 only:
                     - master
-      - production_deploy:
+      - deploy:
+          name: production_deploy_live_1
+          namespace: production
           requires:
             - production_deploy_approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,10 @@ jobs:
             source .circleci/define_build_environment_variables
             trivy --exit-code 1 --severity CRITICAL --no-progress ${ECR_DEPLOY_IMAGE}
 
-  staging_deploy:
+  deploy:
+    parameters:
+      namespace:
+        type: string
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
     steps:
@@ -159,9 +162,9 @@ jobs:
             setup-kube-auth
             kubectl config use-context staging
       - deploy:
-          name: Deploy laalaa to staging
+          name: Deploy to << parameters.namespace >>
           command: |
-            .circleci/deploy_to_kubernetes staging
+            .circleci/deploy_to_kubernetes << parameters.namespace >>
       - slack/status
 
   production_deploy:
@@ -197,13 +200,15 @@ workflows:
           type: approval
           requires:
             - build
-      - staging_deploy:
+      - deploy:
+          name: staging_deploy_live_1
+          namespace: staging
           requires:
             - staging_deploy_approval
       - production_deploy_approval:
           type: approval
           requires:
-            - staging_deploy
+            - staging_deploy_live_1
             - image_security_scan
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
       namespace:
         type: string
     docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+      - image: ministryofjustice/cloud-platform-tools
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,10 +157,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Initialise Kubernetes << parameters.namespace >> context
+          name: Authenticate with cluster
           command: |
-            setup-kube-auth
-            kubectl config use-context << parameters.namespace >>
+            echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt
+            kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=./ca.crt --server=${K8S_SERVER_ADDRESS}
+            kubectl config set-credentials circleci --token=${K8S_TOKEN}
+            kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}
+            kubectl config use-context ${K8S_CLUSTER_NAME}
+            kubectl --namespace=${K8S_NAMESPACE} get pods
       - deploy:
           name: Deploy to << parameters.namespace >>
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,3 +212,5 @@ workflows:
           namespace: production
           requires:
             - production_deploy_approval
+          context:
+            - laa-legal-adviser-api-live1-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,15 +184,20 @@ workflows:
       - image_security_scan:
           requires:
             - build
+
       - staging_deploy_approval:
           type: approval
           requires:
             - build
+
       - deploy:
           name: staging_deploy_live_1
           namespace: staging
           requires:
             - staging_deploy_approval
+          context:
+            - laa-legal-adviser-api-live1-staging
+
       - production_deploy_approval:
           type: approval
           requires:


### PR DESCRIPTION
## What does this pull request do?

Remove usage of deprecated setup-kube-auth
Create reusable deploy job and both staging/production deployments use new deploy job

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
