### PR TITLE
LGA-1927 deploy staging to live

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ workflows:
 
       - deploy:
           name: staging_deploy_live_1
-          namespace: staging
+          namespace: staging-live1
           requires:
             - staging_deploy_approval
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,14 @@ workflows:
           context:
             - laa-legal-adviser-api-live1-staging
 
+      - deploy:
+          name: staging_deploy_live
+          namespace: staging
+          requires:
+            - staging_deploy_approval
+          context:
+            - laa-legal-adviser-api-live-staging
+
       - production_deploy_approval:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ jobs:
 
   deploy:
     parameters:
-      namespace:
+      environment:
         type: string
     docker:
       - image: ministryofjustice/cloud-platform-tools
@@ -166,9 +166,9 @@ jobs:
             kubectl config use-context ${K8S_CLUSTER_NAME}
             kubectl --namespace=${K8S_NAMESPACE} get pods
       - deploy:
-          name: Deploy to << parameters.namespace >>
+          name: Deploy to << parameters.environment >>
           command: |
-            .circleci/deploy_to_kubernetes << parameters.namespace >>
+            .circleci/deploy_to_kubernetes << parameters.environment >>
       - slack/status
 
 workflows:
@@ -192,7 +192,7 @@ workflows:
 
       - deploy:
           name: staging_deploy_live_1
-          namespace: staging-live1
+          environment: staging-live1
           requires:
             - staging_deploy_approval
           context:
@@ -200,7 +200,7 @@ workflows:
 
       - deploy:
           name: staging_deploy_live
-          namespace: staging
+          environment: staging
           requires:
             - staging_deploy_approval
           context:
@@ -217,7 +217,7 @@ workflows:
                     - master
       - deploy:
           name: production_deploy_live_1
-          namespace: production
+          environment: production
           requires:
             - production_deploy_approval
           context:

--- a/kubernetes_deploy/staging-live1/collect-static-job.yml
+++ b/kubernetes_deploy/staging-live1/collect-static-job.yml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
+  name: laa-legal-adviser-api-collect-static
+spec:
+  template:
+    metadata:
+      name: laa-legal-adviser-api-collect-static
+      labels:
+        app: laa-legal-adviser-api
+        tier: collect-static
+        type: job
+        env: staging
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: app
+        image: "<to be set by deploy_to_kubernetes>"
+        command: ["python", "manage.py", "collectstatic", "--noinput"]
+        env:
+        - name: ENV
+          value: staging
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret-key
+              key: SECRET_KEY
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: sentry
+              key: dsn
+        - name: STATIC_FILES_BACKEND
+          value: s3
+        - name: AWS_STORAGE_BUCKET_NAME
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: bucket_name
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: access_key_id
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: secret_access_key
+        - name: AWS_S3_REGION_NAME
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: region

--- a/kubernetes_deploy/staging-live1/deployment.yml
+++ b/kubernetes_deploy/staging-live1/deployment.yml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
+  name: laa-legal-adviser-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: laa-legal-adviser-api
+      tier: api
+      env: staging
+  template:
+    metadata:
+      labels:
+        app: laa-legal-adviser-api
+        tier: api
+        env: staging
+        service_area: laa-get-access
+        service_team: cla-fala
+    spec:
+      containers:
+      - image: "<to be set by deploy_to_kubernetes>"
+        name: app
+        readinessProbe:
+          httpGet:
+            path: /healthcheck.json
+            port: 8000
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthcheck.json
+            port: 8000
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+          periodSeconds: 10
+        env:
+        - name: ENV
+          value: staging
+        - name: LOG_LEVEL
+          value: INFO
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret-key
+              key: SECRET_KEY
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: sentry
+              key: dsn
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: database
+              key: url
+        - name: STATIC_FILES_BACKEND
+          value: s3
+        - name: AWS_STORAGE_BUCKET_NAME
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: bucket_name
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: access_key_id
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: secret_access_key
+        - name: AWS_S3_REGION_NAME
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: region
+        - name: CELERY_BROKER_URL
+          valueFrom:
+            secretKeyRef:
+              name: celery-broker
+              key: url
+        - name: CELERY_BROKER_USE_SSL
+          value: "true"

--- a/kubernetes_deploy/staging-live1/ingress.yml
+++ b/kubernetes_deploy/staging-live1/ingress.yml
@@ -4,8 +4,8 @@ metadata:
   name: laa-legal-adviser-api
   namespace: laa-legal-adviser-api-staging
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: laa-legal-adviser-api-laa-legal-adviser-api-staging-green
-    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    external-dns.alpha.kubernetes.io/set-identifier: laa-legal-adviser-api-laa-legal-adviser-api-staging-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:

--- a/kubernetes_deploy/staging-live1/ingress.yml
+++ b/kubernetes_deploy/staging-live1/ingress.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-legal-adviser-api-staging
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-legal-adviser-api-laa-legal-adviser-api-staging-blue
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/aws-weight: "0"
 spec:
   tls:
   - hosts:

--- a/kubernetes_deploy/staging-live1/migrate-db-job.yml
+++ b/kubernetes_deploy/staging-live1/migrate-db-job.yml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
+  name: laa-legal-adviser-api-migrate-db
+spec:
+  template:
+    metadata:
+      name: laa-legal-adviser-api-migrate-db
+      labels:
+        app: laa-legal-adviser-api
+        tier: migrate-db
+        type: job
+        env: staging
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: app
+        image: "<to be set by deploy_to_kubernetes>"
+        command: ["python", "manage.py", "migrate", "--noinput"]
+        env:
+        - name: ENV
+          value: staging
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret-key
+              key: SECRET_KEY
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: database
+              key: url

--- a/kubernetes_deploy/staging-live1/queue_worker_deployment.yml
+++ b/kubernetes_deploy/staging-live1/queue_worker_deployment.yml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
+  name: laa-legal-adviser-api-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: laa-legal-adviser-api
+      tier: worker
+      env: staging
+  template:
+    metadata:
+      labels:
+        app: laa-legal-adviser-api
+        tier: worker
+        env: staging
+        service_area: laa-get-access
+        service_team: cla-fala
+    spec:
+      containers:
+      - image: "<to be set by deploy_to_kubernetes>"
+        name: worker
+        args: ["docker/run_worker.sh"]
+        readinessProbe:
+          exec:
+            command: ["docker/workers_healthcheck.sh"]
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+        livenessProbe:
+          exec:
+            command: ["docker/workers_healthcheck.sh"]
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+          periodSeconds: 10
+        env:
+        - name: ENV
+          value: staging
+        - name: WORKER_APP_CONCURRENCY
+          value: "8"
+        - name: LOG_LEVEL
+          value: INFO
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret-key
+              key: SECRET_KEY
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: sentry
+              key: dsn
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: database
+              key: url
+        - name: CELERY_BROKER_URL
+          valueFrom:
+            secretKeyRef:
+              name: celery-broker
+              key: url
+        - name: CELERY_BROKER_USE_SSL
+          value: "true"

--- a/kubernetes_deploy/staging-live1/service.yml
+++ b/kubernetes_deploy/staging-live1/service.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: laa-legal-adviser-api
+  namespace: laa-legal-adviser-api-staging
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: 8000
+  selector:
+    app: laa-legal-adviser-api
+    tier: api

--- a/kubernetes_deploy/staging/ingress.yml
+++ b/kubernetes_deploy/staging/ingress.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: laa-legal-adviser-api-staging
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-legal-adviser-api-laa-legal-adviser-api-staging-green
-    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
## What does this pull request do?

Deploy staging to the new live cluster
Create new `kubernetes_deploy/staging-live1` deployment files and deploy to live-1 cluster
Deploy existing `kubernetes_deploy/staging` deployment files to new live cluster
Set `kubernetes_deploy/staging-live1` ingress weight to 0% so that it does not receive any traffic
Set `kubernetes_deploy/staging` ingress weight to 100% so that it receives all of the traffic

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
