### PR TITLE
Remove celery status check from worker pod health checks

### DIFF
--- a/docker/workers_healthcheck.sh
+++ b/docker/workers_healthcheck.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -e
 exec ./manage.py worker_health_checks
-exec celery -A laalaa status
+# This timeouts on the new cluster and there is no way to pass the --timeout option in this version of celery
+# exec celery -A laalaa status


### PR DESCRIPTION
## What does this pull request do?

Remove celery status check from worker pod health checks

## Any other changes that would benefit highlighting?

The command `exec celery -A laalaa status` times out on the new kubernetes live cluster.
A --timeout option has been added to the status on later version of celery

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
