### PR TITLE
Disable readiness and liveness probes

### DIFF
--- a/kubernetes_deploy/production/queue_worker_deployment.yml
+++ b/kubernetes_deploy/production/queue_worker_deployment.yml
@@ -24,18 +24,18 @@ spec:
       - image: "<to be set by deploy_to_kubernetes>"
         name: worker
         args: ["docker/run_worker.sh"]
-        readinessProbe:
-          exec:
-            command: ["docker/workers_healthcheck.sh"]
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
-          periodSeconds: 10
-        livenessProbe:
-          exec:
-            command: ["docker/workers_healthcheck.sh"]
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
-          periodSeconds: 10
+#        readinessProbe:
+#          exec:
+#            command: ["docker/workers_healthcheck.sh"]
+#          initialDelaySeconds: 5
+#          timeoutSeconds: 1
+#          periodSeconds: 10
+#        livenessProbe:
+#          exec:
+#            command: ["docker/workers_healthcheck.sh"]
+#          initialDelaySeconds: 10
+#          timeoutSeconds: 1
+#          periodSeconds: 10
         env:
         - name: ENV
           value: prod

--- a/kubernetes_deploy/staging/queue_worker_deployment.yml
+++ b/kubernetes_deploy/staging/queue_worker_deployment.yml
@@ -24,18 +24,18 @@ spec:
       - image: "<to be set by deploy_to_kubernetes>"
         name: worker
         args: ["docker/run_worker.sh"]
-        readinessProbe:
-          exec:
-            command: ["docker/workers_healthcheck.sh"]
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
-          periodSeconds: 10
-        livenessProbe:
-          exec:
-            command: ["docker/workers_healthcheck.sh"]
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
-          periodSeconds: 10
+#        readinessProbe:
+#          exec:
+#            command: ["docker/workers_healthcheck.sh"]
+#          initialDelaySeconds: 5
+#          timeoutSeconds: 1
+#          periodSeconds: 10
+#        livenessProbe:
+#          exec:
+#            command: ["docker/workers_healthcheck.sh"]
+#          initialDelaySeconds: 10
+#          timeoutSeconds: 1
+#          periodSeconds: 10
         env:
         - name: ENV
           value: staging


### PR DESCRIPTION
## What does this pull request do?

Disable readiness and liveness probes

## Any other changes that would benefit highlighting?

The probes were inconsistently(most failing) working and causing the worker pod to restart and then eventually crash.
They need to be disabled so that the monthly laalaa upload can be done.
https://dsdmoj.atlassian.net/browse/LGA-2050 has been created to investigate the probe failures and to re-enable them

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
