### PR TITLE
LGA-2127 - Add modsec in detection only mode and created new ingress for v122

### DIFF
--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -6,7 +6,11 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-legal-adviser-api-laa-legal-adviser-api-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleRemoveById 200001
 spec:
+  ingressClassName: "modsec"
   tls:
   - hosts:
     - laa-legal-adviser-api-production.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -1,10 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: laa-legal-adviser-api
+  name: laa-legal-adviser-api-v122
   namespace: laa-legal-adviser-api-production
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: laa-legal-adviser-api-laa-legal-adviser-api-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: laa-legal-adviser-api-v122-laa-legal-adviser-api-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |

--- a/kubernetes_deploy/staging/ingress.yml
+++ b/kubernetes_deploy/staging/ingress.yml
@@ -6,7 +6,11 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-legal-adviser-api-laa-legal-adviser-api-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleRemoveById 200001
 spec:
+  ingressClassName: "modsec"
   tls:
   - hosts:
     - laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/kubernetes_deploy/staging/ingress.yml
+++ b/kubernetes_deploy/staging/ingress.yml
@@ -1,10 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: laa-legal-adviser-api
+  name: laa-legal-adviser-api-v122
   namespace: laa-legal-adviser-api-staging
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: laa-legal-adviser-api-laa-legal-adviser-api-staging-green
+    external-dns.alpha.kubernetes.io/set-identifier: laa-legal-adviser-api-v122-laa-legal-adviser-api-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ boto3==1.9.159
 celery[redis]==4.4.0
 django-celery-results==1.1.2
 django-filter==1.1
-django==2.2.10
+django==2.2.28
 django-storages==1.7.1
 djangorestframework-gis==0.14.0
 djangorestframework==3.11.2


### PR DESCRIPTION
## What does this pull request do?
Updated django to 2.2.28 to fix https://avd.aquasec.com/nvd/2022/cve-2022-28346/)
Add modsec in detection only mode
Create new ingress that has spec.ingressClassName set to 'modsec' so that the new v122 ingress controller is used

## Any other changes that would benefit highlighting?
The ingress `laa-legal-adviser-api` on both staging and production has had it's annotation `external-dns.alpha.kubernetes.io/aws-weight`  set to 0

When this PR is merged a new `laa-legal-adviser-api-v122` will be created with `external-dns.alpha.kubernetes.io/aws-weight` of 100

The new ingress will take a while to setup(DNS propagation), in that time the old ingress will continue to service request.
Once the new ingress is ready, the old ingress needs to be manually removed

More information can be found on the user guide https://runbooks.cloud-platform.service.justice.gov.uk/Switch-ingress-to-v1-ingress-controller.html#switch-ingress-to-the-new-nginx-ingress-controller-v1-2

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
