### PR TITLE
Pinned version of importlib_metadata to work with python 3.7.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,3 +14,4 @@ uwsgi==2.0.17.1
 xlrd==1.2.0
 django-moj-irat>=0.4
 dj-database-url==0.5.0
+importlib_metadata==4.11.4


### PR DESCRIPTION
## What does this pull request do?

- [x] Pinned the version of `importlib_metadata` to work with python 3.7. This was causing an issue with installing dependencies via the CI pipeline. 


