### PR TITLE
LGA-2589 Remove S from the end of services

### DIFF
--- a/laalaa/apps/advisers/models.py
+++ b/laalaa/apps/advisers/models.py
@@ -29,7 +29,7 @@ PROVIDER_CATEGORIES = {
     "pub": "Public law",
     "wb": "Welfare benefits",
     "mosl": "Modern slavery",
-    "hlpas": "Housing Loss Prevention Advice Services",
+    "hlpas": "Housing Loss Prevention Advice Service",
 }
 
 


### PR DESCRIPTION
## What does this pull request do?

Required.

Removing the letter S from the end of service.

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
