### PR TITLE
Add CCQ to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*      @ministryofjustice/laa-get-access
+*      @ministryofjustice/laa-get-access @ministryofjustice/check-client-qualifies-reviewers


### PR DESCRIPTION
This means:
* CCQ are notified about PRs that need reviewing.
* CCQ reviews count towards being able to merge the PR (according to the branch protection that "Requires review from Code Owners")

I'm leaving Team 1 on the codeowners list, for the time being, for a handover period, or emergency help.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
