### PR TITLE
Remove Team 1 from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*      @ministryofjustice/laa-get-access @ministryofjustice/check-client-qualifies-reviewers
+*      @ministryofjustice/check-client-qualifies-reviewers


### PR DESCRIPTION
so that they stop getting notifications

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
