### PR TITLE
EL-1457 Django upgrade

### DIFF
--- a/laalaa/apps/advisers/admin.py
+++ b/laalaa/apps/advisers/admin.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin
 from django.db.models import Q
 from django.views.generic import TemplateView
@@ -53,15 +53,15 @@ class MyAdminSite(admin.AdminSite):
     def get_urls(self):
         urls = super(MyAdminSite, self).get_urls()
         my_urls = [
-            url(r"^upload/$", views.upload_spreadsheet),
-            url(
+            re_path(r"^upload/$", views.upload_spreadsheet),
+            re_path(
                 r"^import-in-progress/$",
                 TemplateView.as_view(
                     template_name="import_progress.html", get_context_data=lambda: {"title": "Importing data"}
                 ),
                 name="import_in_progress",
             ),
-            url(r"^import-progress/$", views.import_progress),
+            re_path(r"^import-progress/$", views.import_progress),
         ]
         return my_urls + urls
 

--- a/laalaa/apps/advisers/urls.py
+++ b/laalaa/apps/advisers/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import re_path, include
 
 from rest_framework import routers
 
@@ -10,4 +10,4 @@ router = routers.DefaultRouter()
 router.register(r"legal-advisers", views.AdviserViewSet, basename="legal-advisers")
 router.register(r"categories_of_law", CategoryViewSet, basename="categories")
 
-urlpatterns = [url(r"^", include(router.urls))]
+urlpatterns = [re_path(r"^", include(router.urls))]

--- a/laalaa/settings/base.py
+++ b/laalaa/settings/base.py
@@ -43,6 +43,8 @@ SECRET_KEY = os.environ.get("SECRET_KEY", "DEV_KEY")
 
 DEBUG = False
 
+GDAL_LIBRARY_PATH = '/opt/homebrew/opt/gdal/lib/libgdal.dylib'
+GEOS_LIBRARY_PATH = '/opt/homebrew/opt/geos/lib/libgeos_c.dylib'
 TEMPLATE_DEBUG = False
 
 ALLOWED_HOSTS = ["*"]

--- a/laalaa/urls.py
+++ b/laalaa/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.conf.urls.static import static
 from django.views.decorators.cache import never_cache
 
@@ -7,8 +7,8 @@ from advisers.admin import admin_site
 from moj_irat.views import HealthcheckView
 
 urlpatterns = [
-    url(r"^healthcheck.json$", never_cache(HealthcheckView.as_view()), name="healthcheck_json"),
-    url(r"^admin/", admin_site.urls),
-    url(r"^", include("advisers.urls")),
-    url("", include("django_prometheus.urls")),
+    re_path(r"^healthcheck.json$", never_cache(HealthcheckView.as_view()), name="healthcheck_json"),
+    re_path(r"^admin/", admin_site.urls),
+    re_path(r"^", include("advisers.urls")),
+    re_path("", include("django_prometheus.urls")),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,11 +1,11 @@
-requests==2.30.0
-boto3==1.24.95
-celery[sqs]==5.2.3
+requests==2.32.3
+boto3==1.34.139
+celery[sqs]==5.4
 pycurl>=7.43.0.5; sys_platform != 'win32' and platform_python_implementation=="CPython"
-django-celery-results==2.4.0
-django-filter==2.4.0
-django==4.2
-django-storages==1.13.1
+django-celery-results==2.5.1
+django-filter==24.2
+django==4.2.13
+django-storages==1.14.3
 djangorestframework-gis==1.0.0
 djangorestframework==3.15.2
 django-prometheus<3
@@ -14,6 +14,6 @@ psycopg2-binary==2.9.4
 sentry-sdk==0.19.3
 uwsgi==2.0.22
 xlrd==1.2.0
-django-moj-irat>=0.4
-dj-database-url==0.5.0
-importlib_metadata==4.13.0
+django-moj-irat>=0.9
+dj-database-url==2.2.0
+importlib_metadata==8.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,10 +4,10 @@ celery[sqs]==5.2.3
 pycurl>=7.43.0.5; sys_platform != 'win32' and platform_python_implementation=="CPython"
 django-celery-results==2.4.0
 django-filter==2.4.0
-django==4.0
+django==4.2
 django-storages==1.13.1
 djangorestframework-gis==1.0.0
-djangorestframework==3.13
+djangorestframework==3.14
 django-prometheus<3
 logstash-formatter==0.5.9
 psycopg2-binary==2.9.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ celery[sqs]==5.2.3
 pycurl>=7.43.0.5; sys_platform != 'win32' and platform_python_implementation=="CPython"
 django-celery-results==2.4.0
 django-filter==2.4.0
-django==3.2.25
+django==4.0
 django-storages==1.13.1
 djangorestframework-gis==1.0.0
 djangorestframework==3.13

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ django-filter==2.4.0
 django==4.2
 django-storages==1.13.1
 djangorestframework-gis==1.0.0
-djangorestframework==3.14
+djangorestframework==3.15.2
 django-prometheus<3
 logstash-formatter==0.5.9
 psycopg2-binary==2.9.4


### PR DESCRIPTION
## What does this pull request do?

Upgrade Django and requirements sequentially to get to latest version of as many as possible.
Cant go up to Django 5 because many of the requirements do not support/are not supported on that version:

    The user requested django==5.0
    django-celery-results 2.5.1 depends on Django>=3.2.18
    django-filter 24.2 depends on Django>=4.2
    django-storages 1.14.3 depends on Django>=3.2
    djangorestframework 3.15.2 depends on django>=4.2
    dj-database-url 2.2.0 depends on Django>=3.2
    django-moj-irat 0.9 depends on Django<4.3 and >=2.2

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
