### PR TITLE
EL-1644: Adding some connection retries to LAALAA Postcode lookup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # LAA Legal Adviser API
 
+
 [![Coverage Status](https://coveralls.io/repos/github/ministryofjustice/laa-legal-adviser-api/badge.svg?branch=master)](https://coveralls.io/github/ministryofjustice/laa-legal-adviser-api?branch=master)
 
 Service to search for nearby LAA Legal Advisers by postcode.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # LAA Legal Adviser API
 
-
 [![Coverage Status](https://coveralls.io/repos/github/ministryofjustice/laa-legal-adviser-api/badge.svg?branch=master)](https://coveralls.io/github/ministryofjustice/laa-legal-adviser-api?branch=master)
 
 Service to search for nearby LAA Legal Advisers by postcode.

--- a/laalaa/apps/advisers/geocoder.py
+++ b/laalaa/apps/advisers/geocoder.py
@@ -2,7 +2,7 @@ import json
 import logging
 import requests
 from django.conf import settings
-from requests.adapters import HTTPAdapter
+from requests.adapters import HTTPAdapter, Retry
 
 
 class PostcodePlaceholder:
@@ -41,9 +41,11 @@ def lookup_postcode(postcode):
 
     session = requests.Session()
 
+    retry_stratergy = Retry(total=5, backoff_factor=0.1)
+
     # `max_retries` only applies to failed DNS lookups, socket connections and connection timeouts, never to requests where data has made it to the server.
     # by default, Requests does not retry failed connections. Please see documentation: https://docs.python-requests.org/en/latest/api/#requests.adapters.HTTPAdapter
-    session.mount("https://api.postcodes.io/", HTTPAdapter(max_retries=5))
+    session.mount("https://", HTTPAdapter(max_retries=retry_stratergy))
 
     raw = session.get(
         "{host}/postcodes/?q={postcode}&limit=1".format(host=settings.POSTCODES_IO_URL, postcode=normalised_postcode)

--- a/laalaa/apps/advisers/geocoder.py
+++ b/laalaa/apps/advisers/geocoder.py
@@ -41,11 +41,11 @@ def lookup_postcode(postcode):
 
     session = requests.Session()
 
-    retry_stratergy = Retry(total=5, backoff_factor=0.1)
+    retry_strategy = Retry(total=5, backoff_factor=0.1)
 
     # `max_retries` only applies to failed DNS lookups, socket connections and connection timeouts, never to requests where data has made it to the server.
     # by default, Requests does not retry failed connections. Please see documentation: https://docs.python-requests.org/en/latest/api/#requests.adapters.HTTPAdapter
-    session.mount("https://", HTTPAdapter(max_retries=retry_stratergy))
+    session.mount("https://", HTTPAdapter(max_retries=retry_strategy))
 
     raw = session.get(
         "{host}/postcodes/?q={postcode}&limit=1".format(host=settings.POSTCODES_IO_URL, postcode=normalised_postcode)

--- a/laalaa/apps/advisers/geocoder.py
+++ b/laalaa/apps/advisers/geocoder.py
@@ -4,6 +4,7 @@ import requests
 from django.conf import settings
 from requests.adapters import HTTPAdapter
 
+
 class PostcodePlaceholder:
     def __init__(self):
         self.postcode = None
@@ -37,13 +38,13 @@ def result_to_postcode(result):
 
 def lookup_postcode(postcode):
     normalised_postcode = normalise_postcode(postcode)
-    
+
     session = requests.Session()
-    
-    # `max_retries` only applies to failed DNS lookups, socket connections and connection timeouts, never to requests where data has made it to the server. 
+
+    # `max_retries` only applies to failed DNS lookups, socket connections and connection timeouts, never to requests where data has made it to the server.
     # by default, Requests does not retry failed connections. Please see documentation: https://docs.python-requests.org/en/latest/api/#requests.adapters.HTTPAdapter
     session.mount("https://api.postcodes.io/", HTTPAdapter(max_retries=5))
-    
+
     raw = session.get(
         "{host}/postcodes/?q={postcode}&limit=1".format(host=settings.POSTCODES_IO_URL, postcode=normalised_postcode)
     )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@ django-extensions
 werkzeug
 mock
 responses==0.25.3
-pre-commit==1.14.2
+pre-commit==3.8.0
 unittest-xml-reporting==3.0.2
 coverage==5.0.3
 coveralls==3.3.1


### PR DESCRIPTION
## What does this pull request do?

- using 'requests' `HTTPAdapter` & 'urllib3' `Retry` to up the retries to third party postcode api.

## Any other changes that would benefit highlighting?

- upping the retries to 5, but happy to up this further if needed.
- also updated `pre-commit` version as was having trouble with packages 
- have used this as a [template](https://github.com/ministryofjustice/operations-engineering/blob/f83e228b056eeb84e2722e429d89498a98df56bd/services/operations_engineering_reports.py#L4) 

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
