### PR TITLE
EL-2032: Prevent page refresh when `.xlsx` upload complete, in order to copy 'postcode errors'

### DIFF
--- a/laalaa/templates/import_progress.html
+++ b/laalaa/templates/import_progress.html
@@ -92,7 +92,7 @@ $(function () {
       var labelText = data.status || 'No import running';
       label.text(labelText);
     }
-    if (data.task === 'done' || data.status === 'not running') {
+    if (data.task === 'done' || data.status === 'not running' || label.text === "success") {
       window.clearInterval(polling);
       progressBar.remove();
       counts.remove();

--- a/laalaa/templates/import_progress.html
+++ b/laalaa/templates/import_progress.html
@@ -92,7 +92,7 @@ $(function () {
       var labelText = data.status || 'No import running';
       label.text(labelText);
     }
-    if (data.task === 'done' || data.status === 'not running' || label.text === "success") {
+    if (data.task === 'done' || data.status === 'not running' || label.text() === "success") {
       window.clearInterval(polling);
       progressBar.remove();
       counts.remove();


### PR DESCRIPTION
## What does this pull request do?

- If applied, this change will stop refresh of page, remove progress bar and count once the `success` text is on the screen
- the end result will look like this after a successful upload

<img width="773" alt="Screenshot 2025-03-03 at 11 13 30" src="https://github.com/user-attachments/assets/1100c55a-d578-4c5e-889b-4eb9ded093e8" />


## Any other changes that would benefit highlighting?

- n/a

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
