### PR TITLE
remove approval steps from pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,40 +227,29 @@ workflows:
           requires:
             - build
 
-      - staging_deploy_approval:
-          type: approval
-          requires:
-            - build
-
       - deploy:
           name: staging_deploy_live
           environment: staging
-          requires:
-            - staging_deploy_approval
           context:
             - laa-legal-adviser-api-live-staging
+          requires:
+            - image_security_scan
 
       - deploy_grafana:
           name: deploy_grafana
-          requires:
-            - staging_deploy_approval
           context:
             - laa-legal-adviser-api-live-staging
-
-      - production_deploy_approval:
-          type: approval
           requires:
-            - staging_deploy_live
+            - image_security_scan
+
+      - deploy:
+          name: production_deploy_live
+          environment: production
+          context:
+            - laa-legal-adviser-api-live-production
+          requires:
             - image_security_scan
           filters:
             branches:
                 only:
                     - main
-
-      - deploy:
-          name: production_deploy_live
-          environment: production
-          requires:
-            - production_deploy_approval
-          context:
-            - laa-legal-adviser-api-live-production


### PR DESCRIPTION
## What does this pull request do?
removes the approval steps from the circleci pipeline
this repo does not need much maintenance and we dont use approval steps in our other pipelines so merges can sometimes be forgotten to be released. This is also inline with the CI/CD guardrails which prefer continuous deployment
 ie. fully automated deployment pipelines


## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
